### PR TITLE
Fix theme dropdown icon placement

### DIFF
--- a/app/templates/components/changeTheme.html
+++ b/app/templates/components/changeTheme.html
@@ -1,5 +1,4 @@
-<div class="absolute right-2 top-2">
-    <div class="dropdown dropdown-end">
+<div class="dropdown dropdown-end absolute right-2 top-2">
         <button
             tabindex="0"
             class="btn btn-ghost btn-circle text-3xl"
@@ -259,4 +258,3 @@
             </li>
         </ul>
     </div>
-</div>


### PR DESCRIPTION
## Summary
- Revert previous theme dropdown icon change
- Use ≡ symbol as theme dropdown trigger and merge absolute positioning into dropdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afeff3a9848327946eb5c0b8902388