### PR TITLE
Use text-based button for sort dropdown

### DIFF
--- a/app/templates/components/sortMenu.html
+++ b/app/templates/components/sortMenu.html
@@ -1,12 +1,14 @@
 {% macro sortMenu(sortName,source,translations) %}
 <div class="dropdown">
-    <div
+    <button
         tabindex="0"
-        role="button"
+        type="button"
         class="btn w-full md:w-fit text-base-content"
+        aria-label="{{ sortName }}"
+        title="{{ sortName }}"
     >
-        {{sortName}}
-    </div>
+        &#8801;
+    </button>
     <ul
         tabindex="0"
         class="dropdown-content menu bg-base-100 rounded-box z-1 w-full md:w-fit p-2 shadow-sm"


### PR DESCRIPTION
## Summary
- Replace sort menu image trigger with a semantic button displaying the ≡ symbol
- Preserve accessibility by setting button aria-label and title from the active sort

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff4e373888327b077b3465dd10c54