### PR TITLE
Hide banner and search on article pages

### DIFF
--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -86,6 +86,8 @@ def post(urlID: int, slug: str | None = None):
         content=content,
         reading_time=reading_time,
         author_info=author_info,
+        hideNavbar=True,
+        hideSearch=True,
     )
 
 

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -9,6 +9,7 @@
         />
     </a>
 
+    {% if not hideSearch %}
     <div class="hidden md:block">
         <input
             type="text"
@@ -21,11 +22,14 @@
             <i class="ti ti-search text-2xl"></i>
         </button>
     </div>
+    {% endif %}
 
     <div class="flex items-center justify-center gap-4 font-medium select-none">
+        {% if not hideSearch %}
         <div class="block md:hidden">
             <a href="/searchbar"><i class="ti ti-search text-2xl"></i></a>
         </div>
+        {% endif %}
 
         {% if session["userName"] %}
         <a href="/dashboard/{{ session['userName'].lower() }}">

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -72,9 +72,12 @@
 
     <body id="body">
         <div id="progress-bar"></div>
-        {% include 'components/changeTheme.html'%} {% include
-        'components/navbar.html'%} {% from "components/flash.html" import flash
-        %} {{ flash() }} {% block body %} {% endblock body %}
+        {% include 'components/changeTheme.html'%}
+        {% if not hideNavbar %}
+        {% include 'components/navbar.html'%}
+        {% endif %}
+        {% from "components/flash.html" import flash %} {{ flash() }}
+        {% block body %} {% endblock body %}
 
         <div id="post-overlay" class="hidden">
             <div class="overlay-content">


### PR DESCRIPTION
## Summary
- Add optional navbar inclusion in layout so posts can hide the front page banner
- Allow navbar to toggle search field visibility
- Update post route to suppress banner and search on article pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affc65168c8327bd4800ef7e27d467