### PR TITLE
fix: avoid debug logger crash in comment tree

### DIFF
--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -1,5 +1,8 @@
 (() => {
-  const debug = (...args) => window.debugLog('post.js', ...args);
+  const debug = (...args) =>
+    (window.debugLog
+      ? window.debugLog('post.js', ...args)
+      : console.log('post.js', ...args));
   debug('Loaded');
 
 let currentTreeSignature = "";


### PR DESCRIPTION
## Summary
- prevent comment tree JS from crashing when debug logger is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a044cbfc8327b66948ec7e3fd3e2