### PR TITLE
Fix comment tree rendering syntax error

### DIFF
--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -167,4 +167,5 @@ function renderCommentTree(data) {
   }
 
   showAll();
+}
 })();


### PR DESCRIPTION
## Summary
- close `renderCommentTree` function to fix comment tree syntax

## Testing
- `node --check app/static/js/post.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0a25bad28832783a0f958069a259c