### PR TITLE
Include disconnected comments in radial tree

### DIFF
--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -60,7 +60,19 @@ function renderCommentTree(data) {
     };
   }
 
+  // Build the primary tree starting from the first node returned.
   const root = d3.hierarchy(build(rootId));
+  // Ensure disconnected nodes (no links) are also displayed by attaching them
+  // as children of the root node so that every comment appears in the radial
+  // tree.
+  const seen = new Set(root.descendants().map((d) => d.data.id));
+  data.nodes.forEach((n) => {
+    if (!seen.has(n.id)) {
+      const child = d3.hierarchy(build(n.id));
+      child.parent = root;
+      (root.children ||= []).push(child);
+    }
+  });
   const width = 600;
   const radius = width / 2;
 


### PR DESCRIPTION
## Summary
- ensure comment tree renders nodes with no similarity links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0a6e974cc83278519b2590873feb7