### PR TITLE
feat: support pdf banners

### DIFF
--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -19,6 +19,7 @@
 <div class="w-11/12 md:w-5/6 lg:w-7/12 xl:w-5/12 mx-auto mt-6 md:mt-10 break-words">
     <img
         data-magnet-id="{{ id }}.png"
+        data-allow-download="true"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
         class="mx-auto rounded-md shadow-md select-none"
     />


### PR DESCRIPTION
## Summary
- display PDF banners inline and provide download links on posts
- detect PDF magnets and embed them in post tiles or banners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac20643883278ca805d8e9630598