### PR TITLE
Redirect unauthorized admin access to login

### DIFF
--- a/app/routes/adminPanel.py
+++ b/app/routes/adminPanel.py
@@ -10,5 +10,5 @@ def adminPanel():
         Log.info("Rendering adminPanel.html: params: None")
         return render_template("adminPanel.html", admin_check=True)
     Log.error(f"{request.remote_addr} tried to reach admin panel without being admin")
-    return redirect("/")
+    return redirect(f"/login?redirect={request.path}")
 

--- a/app/routes/adminPanelComments.py
+++ b/app/routes/adminPanelComments.py
@@ -32,5 +32,5 @@ def adminPanelComments():
     Log.error(
         f"{request.remote_addr} tried to reach comment admin panel without being admin",
     )
-    return redirect("/")
+    return redirect(f"/login?redirect={request.path}")
 

--- a/app/routes/adminPanelContracts.py
+++ b/app/routes/adminPanelContracts.py
@@ -25,5 +25,5 @@ def adminPanelContracts():
     Log.error(
         f"{request.remote_addr} tried to reach contracts admin panel without being admin"
     )
-    return redirect("/")
+    return redirect(f"/login?redirect={request.path}")
 

--- a/app/routes/adminPanelPosts.py
+++ b/app/routes/adminPanelPosts.py
@@ -42,5 +42,5 @@ def adminPanelPosts():
     Log.error(
         f"{request.remote_addr} tried to reach post admin panel without being admin"
     )
-    return redirect("/")
+    return redirect(f"/login?redirect={request.path}")
 

--- a/app/routes/adminPanelUsers.py
+++ b/app/routes/adminPanelUsers.py
@@ -43,5 +43,5 @@ def adminPanelUsers():
     Log.error(
         f"{request.remote_addr} tried to reach user admin panel without being admin"
     )
-    return redirect("/")
+    return redirect(f"/login?redirect={request.path}")
 


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users from admin routes to the login page
- Preserve target admin URL via redirect parameter for MetaMask authentication

## Testing
- `python -m py_compile app/routes/adminPanel.py app/routes/adminPanelUsers.py app/routes/adminPanelPosts.py app/routes/adminPanelComments.py app/routes/adminPanelContracts.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0bd6f39f08327af4cbad0ce06afff