### PR TITLE
Fix admin check redirect by waiting for wallet to load

### DIFF
--- a/app/static/js/adminCheck.js
+++ b/app/static/js/adminCheck.js
@@ -1,14 +1,14 @@
 (() => {
     const debug = (...args) => window.debugLog('adminCheck.js', ...args);
     debug('Loaded');
-
-    (function() {
-    debug('Checking admin wallet');
-    if (!document.body.classList.contains('admin-wallet')) {
-        debug('Admin wallet not found, redirecting');
-        window.location.replace('/');
-    } else {
-        debug('Admin wallet present');
+    function checkAdmin() {
+        debug('Checking admin wallet');
+        if (!document.body.classList.contains('admin-wallet')) {
+            debug('Admin wallet not found, redirecting');
+            window.location.replace('/');
+        } else {
+            debug('Admin wallet present');
+        }
     }
-    })();
+    window.addEventListener('load', checkAdmin);
 })();


### PR DESCRIPTION
## Summary
- Delay admin authorization check until after window load to avoid premature redirect to home page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c01a7ac08327ad303b9917443d8b