### PR TITLE
Fix stale metrics in post tiles

### DIFF
--- a/app/static/js/postStats.js
+++ b/app/static/js/postStats.js
@@ -7,6 +7,8 @@
             const data = await res.json();
             const overlay = tile.querySelector('.tile-overlay');
             if (!overlay) return;
+            // Remove any existing metadata to ensure metrics are fresh
+            overlay.querySelectorAll('.tile-meta').forEach(span => span.remove());
             const fields = [
                 ['Read', `${data.estimatedReadTime} min`],
                 ['Avg', `${data.avgTimeOnPage}s`],


### PR DESCRIPTION
## Summary
- Clear existing metadata before appending new post statistics so tile metrics stay current

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c0ae61dc8327aa1a6455be36a7a3