### PR TITLE
Enable real-time post metrics and robust admin detection

### DIFF
--- a/app/static/js/adminCheck.js
+++ b/app/static/js/adminCheck.js
@@ -3,12 +3,22 @@
     debug('Loaded');
     function checkAdmin() {
         debug('Checking admin wallet');
-        if (!document.body.classList.contains('admin-wallet')) {
-            debug('Admin wallet not found, redirecting');
-            window.location.replace('/');
-        } else {
+        if (document.body.classList.contains('admin-wallet')) {
             debug('Admin wallet present');
+            return true;
         }
+        return false;
     }
-    window.addEventListener('load', checkAdmin);
+    window.addEventListener('load', () => {
+        const start = Date.now();
+        const interval = setInterval(() => {
+            if (checkAdmin()) {
+                clearInterval(interval);
+            } else if (Date.now() - start > 3000) {
+                debug('Admin wallet not found, redirecting');
+                clearInterval(interval);
+                window.location.replace('/');
+            }
+        }, 100);
+    });
 })();

--- a/app/static/js/postActivity.js
+++ b/app/static/js/postActivity.js
@@ -1,0 +1,18 @@
+(() => {
+    const debug = (...args) => window.debugLog('postActivity.js', ...args);
+    debug('Loaded');
+    if (typeof postUrlID === 'undefined') return;
+    let start = Date.now();
+    function send(action, extra = {}) {
+        fetch('/api/v1/postStats/activity', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ postID: postUrlID, action, ...extra }),
+        }).catch((e) => debug('Failed to send activity', e));
+    }
+    send('enter');
+    window.addEventListener('beforeunload', () => {
+        const timeSpent = Math.round((Date.now() - start) / 1000);
+        send('leave', { timeSpent });
+    });
+})();

--- a/app/static/js/postStats.js
+++ b/app/static/js/postStats.js
@@ -1,14 +1,13 @@
 (() => {
     const debug = (...args) => window.debugLog('postStats.js', ...args);
-    async function loadStats(tile, postId) {
+    async function fetchStats(tile, postId) {
         try {
             const res = await fetch(`/api/v1/postStats?postID=${postId}`);
             if (!res.ok) return;
             const data = await res.json();
             const overlay = tile.querySelector('.tile-overlay');
             if (!overlay) return;
-            // Remove any existing metadata to ensure metrics are fresh
-            overlay.querySelectorAll('.tile-meta').forEach(span => span.remove());
+            overlay.querySelectorAll('.tile-meta').forEach((span) => span.remove());
             const fields = [
                 ['Read', `${data.estimatedReadTime} min`],
                 ['Avg', `${data.avgTimeOnPage}s`],
@@ -25,9 +24,16 @@
             debug('Failed to load stats', e);
         }
     }
+    function loadStats(tile, postId) {
+        fetchStats(tile, postId);
+        if (!tile.dataset.statsInterval) {
+            const id = setInterval(() => fetchStats(tile, postId), 5000);
+            tile.dataset.statsInterval = id;
+        }
+    }
     window.applyPostStats = loadStats;
     document.addEventListener('DOMContentLoaded', () => {
-        document.querySelectorAll('.post-tile').forEach(tile => {
+        document.querySelectorAll('.post-tile').forEach((tile) => {
             const postId = tile.dataset.postId;
             if (postId) loadStats(tile, postId);
         });

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -69,4 +69,5 @@
 <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/comments.js') }}"></script>
 <script src="{{ url_for('static', filename='js/post.js') }}"></script>
+<script src="{{ url_for('static', filename='js/postActivity.js') }}"></script>
 {% endblock scripts %}


### PR DESCRIPTION
## Summary
- Track reader activity with new `/api/v1/postStats/activity` endpoint
- Poll post tiles for up-to-date stats and report per-post activity
- Delay admin check until wallet detection to avoid unwanted redirects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0c26278b48327a522efb1c5a418db