### PR TITLE
feat: add sysop transfer

### DIFF
--- a/contracts/CommentStorage.sol
+++ b/contracts/CommentStorage.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 /// @notice Stores comments associated with posts.
 contract CommentStorage {
     address public sysop;
+    event SysopTransferred(address indexed previousSysop, address indexed newSysop);
 
     struct Comment {
         address author;
@@ -28,6 +29,12 @@ contract CommentStorage {
 
     constructor() {
         sysop = msg.sender;
+    }
+
+    function transferSysop(address newSysop) external onlySysop {
+        require(newSysop != address(0), "bad sysop");
+        emit SysopTransferred(sysop, newSysop);
+        sysop = newSysop;
     }
 
     function addComment(uint256 postId, string calldata content) external returns (uint256 commentId) {

--- a/contracts/PostStorage.sol
+++ b/contracts/PostStorage.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 /// @notice Stores posts and image magnet URIs on-chain.
 contract PostStorage {
     address public sysop;
+    event SysopTransferred(address indexed previousSysop, address indexed newSysop);
 
     struct Post {
         address author;
@@ -38,6 +39,12 @@ contract PostStorage {
 
     constructor() {
         sysop = msg.sender;
+    }
+
+    function transferSysop(address newSysop) external onlySysop {
+        require(newSysop != address(0), "bad sysop");
+        emit SysopTransferred(sysop, newSysop);
+        sysop = newSysop;
     }
 
     function createPost(

--- a/contracts/SponsorSlots.sol
+++ b/contracts/SponsorSlots.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 /// @notice Manages on-chain sponsor ad slots with frequency capping.
 contract SponsorSlots {
     address public sysop;
+    event SysopTransferred(address indexed previousSysop, address indexed newSysop);
 
     struct Slot {
         address sponsor;
@@ -26,6 +27,12 @@ contract SponsorSlots {
 
     constructor() {
         sysop = msg.sender;
+    }
+
+    function transferSysop(address newSysop) external onlySysop {
+        require(newSysop != address(0), "bad sysop");
+        emit SysopTransferred(sysop, newSysop);
+        sysop = newSysop;
     }
 
     function createSlot(uint256 maxImpressions) external onlySysop returns (uint256 slotId) {

--- a/contracts/TipJar.sol
+++ b/contracts/TipJar.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.20;
 contract TipJar {
     address public sysop;
     uint256 public sysopTipBps; // commission in basis points
+    event SysopTransferred(address indexed previousSysop, address indexed newSysop);
 
     mapping(bytes32 => uint256) public tips; // author + postId => total tips
 
@@ -18,6 +19,12 @@ contract TipJar {
 
     constructor() {
         sysop = msg.sender;
+    }
+
+    function transferSysop(address newSysop) external onlySysop {
+        require(newSysop != address(0), "bad sysop");
+        emit SysopTransferred(sysop, newSysop);
+        sysop = newSysop;
     }
 
     function setSysopTipBps(uint256 bps) external onlySysop {

--- a/contracts/UserRegistry.sol
+++ b/contracts/UserRegistry.sol
@@ -12,6 +12,7 @@ contract UserRegistry {
     }
 
     address public sysop;
+    event SysopTransferred(address indexed previousSysop, address indexed newSysop);
     mapping(address => User) public users;
     mapping(Tier => uint256) public freeQuota;
 
@@ -29,6 +30,12 @@ contract UserRegistry {
         freeQuota[Tier.Free] = 3;
         freeQuota[Tier.Premium] = 10;
         freeQuota[Tier.Pro] = type(uint256).max;
+    }
+
+    function transferSysop(address newSysop) external onlySysop {
+        require(newSysop != address(0), "bad sysop");
+        emit SysopTransferred(sysop, newSysop);
+        sysop = newSysop;
     }
 
     function register(address user, Tier tier) external onlySysop {


### PR DESCRIPTION
## Summary
- allow contract owner to transfer the sysop role on storage and utility contracts
- enable future admins to manage posts, comments, registry, tips, and sponsor slots

## Testing
- `npx solc --bin contracts/PostStorage.sol -o /tmp/build`
- `npx solc --bin contracts/CommentStorage.sol contracts/UserRegistry.sol contracts/TipJar.sol contracts/SponsorSlots.sol -o /tmp/build`
- `ls /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68b0c5512ab4832796e0443c564948a4