### PR TITLE
Enable multi-file media uploads with magnet embedding

### DIFF
--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -53,3 +53,21 @@ def createPost():
         post_contract_abi=post_contract["abi"],
         rpc_url=Settings.BLOCKCHAIN_RPC_URL,
     )
+
+
+@createPostBlueprint.route("/uploadmedia", methods=["POST"])
+def upload_media():
+    """Handle generic media uploads and return their magnet URI."""
+    file = request.files.get("file")
+    if not file or file.filename == "":
+        return jsonify({"error": "no file supplied"}), 400
+
+    media_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+    os.makedirs(media_dir, exist_ok=True)
+    filename = secure_filename(file.filename)
+    media_path = os.path.join(media_dir, filename)
+    file.save(media_path)
+
+    magnet = seed_file(media_path)
+    ensure_seeding(media_dir)
+    return jsonify({"magnet": magnet})

--- a/app/static/js/mediaUploader.js
+++ b/app/static/js/mediaUploader.js
@@ -1,0 +1,56 @@
+(() => {
+    const debug = (...args) => window.debugLog('mediaUploader.js', ...args);
+    debug('Loaded');
+
+    window.addEventListener('DOMContentLoaded', () => {
+        const fileInput = document.getElementById('mediaFiles');
+        const uploadBtn = document.getElementById('uploadMedia');
+        const list = document.getElementById('mediaList');
+        if (!fileInput || !uploadBtn || !list) {
+            debug('Required elements not found');
+            return;
+        }
+
+        uploadBtn.addEventListener('click', async () => {
+            const files = Array.from(fileInput.files || []);
+            debug('Uploading files', files.length);
+            for (const file of files) {
+                const formData = new FormData();
+                formData.append('file', file);
+                try {
+                    const res = await fetch('/uploadmedia', {
+                        method: 'POST',
+                        body: formData,
+                    });
+                    const data = await res.json();
+                    if (data.magnet) {
+                        const container = document.createElement('div');
+                        container.className = 'mt-2';
+                        const label = document.createElement('span');
+                        label.className = 'block text-sm';
+                        label.textContent = file.name;
+                        const input = document.createElement('input');
+                        input.type = 'text';
+                        input.readOnly = true;
+                        input.value = data.magnet;
+                        input.className = 'input input-bordered w-full magnet-url';
+                        const copyBtn = document.createElement('button');
+                        copyBtn.type = 'button';
+                        copyBtn.textContent = 'Copy';
+                        copyBtn.className = 'btn btn-xs ml-2';
+                        copyBtn.addEventListener('click', () => navigator.clipboard.writeText(data.magnet));
+                        container.appendChild(label);
+                        container.appendChild(input);
+                        container.appendChild(copyBtn);
+                        list.appendChild(container);
+                    } else {
+                        debug('No magnet returned for', file.name, data);
+                    }
+                } catch (err) {
+                    debug('Upload failed', err);
+                }
+            }
+            fileInput.value = '';
+        });
+    });
+})();

--- a/app/templates/createPost.html
+++ b/app/templates/createPost.html
@@ -48,6 +48,13 @@
             {{ form.newCategory(class_="input input-bordered w-72 mt-2", autocomplete="off", placeholder="New Category") }}
         </div>
 
+        <div class="w-72 mx-auto text-center mt-4">
+            <label class="block mb-1">Upload Media</label>
+            <input id="mediaFiles" type="file" multiple class="file-input file-input-bordered w-full" />
+            <button type="button" id="uploadMedia" class="btn btn-sm btn-neutral w-full mt-2">Upload Selected</button>
+            <div id="mediaList" class="mt-2 text-left"></div>
+        </div>
+
         <div>
             {{ form.postContent(
                 class_="textarea textarea-bordered w-full h-96",
@@ -65,5 +72,6 @@
     <script src="{{ url_for('static', filename='js/bannerMagnet.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
     <script src="{{ url_for('static', filename='js/createPost.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/mediaUploader.js') }}"></script>
 </div>
 {% endblock body %}

--- a/app/utils/markdown_renderer.py
+++ b/app/utils/markdown_renderer.py
@@ -53,7 +53,7 @@ class SafeMarkdownRenderer:
             "a": ["href", "title"],
             "img": ["src", "alt", "title", "width", "height"],
         }
-        self.allowed_protocols = ["http", "https", "mailto"]
+        self.allowed_protocols = ["http", "https", "mailto", "magnet"]
         # Escape any raw HTML before conversion to ensure only Markdown is
         # processed. Fenced code blocks are supported so code is always
         # wrapped in <pre><code> blocks.


### PR DESCRIPTION
## Summary
- Add media upload endpoint and UI for generating magnet URIs
- Allow markdown to include `magnet:` links and render them as images or videos
- Permit magnet links in markdown sanitizer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0d4ae6ee88327a57cfbc987b33461