### PR TITLE
Fix front-page magnet tile image loading

### DIFF
--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -45,7 +45,7 @@
             link.dataset.postId = id;
             link.dataset.w = Math.floor(Math.random() * 3) + 1;
             const img = document.createElement('img');
-            img.dataset.magnetId = `${id}.png`;
+            img.dataset.magnetId = p.bannerImageId;
             img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
             img.alt = title;
             img.className = 'media select-none';


### PR DESCRIPTION
## Summary
- Request magnet images by banner image ID instead of fabricated post ID

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0df87f824832789b3a141a769dd3d