### PR TITLE
fix: save banners to proper images directory

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -53,7 +53,8 @@ class Settings:
     # Application Configuration
     APP_NAME = "flaskBlog"
     APP_VERSION = "3.0.0dev"
-    APP_ROOT_PATH = "."
+    # Determine the repository root to consistently store uploaded files
+    APP_ROOT_PATH = str(Path(__file__).resolve().parent.parent)
     APP_HOST = "0.0.0.0"
     APP_PORT = 80
     DEBUG_MODE = True


### PR DESCRIPTION
## Summary
- derive repository root for APP_ROOT_PATH
- ensure uploaded banners land in the global `images` folder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e17953c08327be16156afb523de4