### PR TITLE
feat: add admin author management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 
 # .DS_Store files
 .DS_Store
+
+# Local runtime blacklist database
+app/db/blacklist.db

--- a/app/app.py
+++ b/app/app.py
@@ -110,6 +110,7 @@ from utils.dbChecker import (
     dbFolder,
     postsTable,
     usersTable,
+    blacklistTable,
 )
 from utils.errorHandlers.csrfErrorHandler import (
     csrfErrorHandler,
@@ -228,6 +229,7 @@ usersTable()
 postsTable()
 commentsTable()
 analyticsTable()
+blacklistTable()
 
 
 @app.errorhandler(404)

--- a/app/routes/adminPanelUsers.py
+++ b/app/routes/adminPanelUsers.py
@@ -1,9 +1,11 @@
+"""Admin panel for listing authors from posts and comments."""
+
+import sqlite3
 from flask import Blueprint, redirect, render_template, request, session
 from settings import Settings
-from utils.changeUserRole import changeUserRole
+from utils.blacklist import Blacklist
 from utils.delete import Delete
 from utils.log import Log
-from utils.paginate import paginate_query
 
 adminPanelUsersBlueprint = Blueprint("adminPanelUsers", __name__)
 
@@ -11,37 +13,84 @@ adminPanelUsersBlueprint = Blueprint("adminPanelUsers", __name__)
 @adminPanelUsersBlueprint.route("/admin/users", methods=["GET", "POST"])
 @adminPanelUsersBlueprint.route("/adminpanel/users", methods=["GET", "POST"])
 def adminPanelUsers():
+    """Render the admin users panel with unique author addresses."""
     if "walletAddress" in session and session.get("userRole") == "admin":
         Log.info(f"Admin: {session['walletAddress']} reached to users admin panel")
         if request.method == "POST":
-            if "userDeleteButton" in request.form:
+            address = request.form.get("address")
+            if "banButton" in request.form:
                 Log.info(
-                    f"Admin: {session['walletAddress']} deleted user: {request.form['userName']}"
+                    f"Admin: {session['walletAddress']} banned user: {address}"
                 )
-                Delete.user(request.form["userName"])
-            if "userRoleChangeButton" in request.form:
+                Delete.user(address)
+                return redirect("/admin/users")
+            if "blacklistButton" in request.form:
                 Log.info(
-                    f"Admin: {session['walletAddress']} changed {request.form['userName']}'s role"
+                    f"Admin: {session['walletAddress']} blacklisted content of: {address}"
                 )
-                changeUserRole(request.form["userName"])
+                Blacklist.add_user_content(address)
+                return redirect("/admin/users")
 
-        users, page, total_pages = paginate_query(
-            Settings.DB_USERS_ROOT,
-            "select count(*) from users",
-            "select * from users",
+        authors = set()
+        try:
+            Log.database(f"Connecting to '{Settings.DB_POSTS_ROOT}' database")
+            connection = sqlite3.connect(Settings.DB_POSTS_ROOT)
+            connection.set_trace_callback(Log.database)
+            cursor = connection.cursor()
+            cursor.execute("select distinct author from posts")
+            authors.update(row[0] for row in cursor.fetchall())
+            connection.close()
+        except Exception as exc:  # pragma: no cover - database may be missing
+            Log.error(f"Fetching post authors failed: {exc}")
+
+        try:
+            Log.database(f"Connecting to '{Settings.DB_COMMENTS_ROOT}' database")
+            connection = sqlite3.connect(Settings.DB_COMMENTS_ROOT)
+            connection.set_trace_callback(Log.database)
+            cursor = connection.cursor()
+            cursor.execute("select distinct user from comments")
+            authors.update(row[0] for row in cursor.fetchall())
+            connection.close()
+        except Exception as exc:  # pragma: no cover - database may be missing
+            Log.error(f"Fetching comment authors failed: {exc}")
+
+        author_data = []
+        for addr in sorted(authors):
+            posts_count = 0
+            comments_count = 0
+            try:
+                connection = sqlite3.connect(Settings.DB_POSTS_ROOT)
+                connection.set_trace_callback(Log.database)
+                cursor = connection.cursor()
+                cursor.execute("select count(*) from posts where author = ?", (addr,))
+                posts_count = cursor.fetchone()[0]
+                connection.close()
+            except Exception as exc:  # pragma: no cover
+                Log.error(f"Counting posts failed: {exc}")
+            try:
+                connection = sqlite3.connect(Settings.DB_COMMENTS_ROOT)
+                connection.set_trace_callback(Log.database)
+                cursor = connection.cursor()
+                cursor.execute(
+                    "select count(*) from comments where user = ?", (addr,)
+                )
+                comments_count = cursor.fetchone()[0]
+                connection.close()
+            except Exception as exc:  # pragma: no cover
+                Log.error(f"Counting comments failed: {exc}")
+            author_data.append(
+                {"address": addr, "posts": posts_count, "comments": comments_count}
+            )
+
+        Log.info(
+            f"Rendering adminPanelUsers.html: params: authors={len(author_data)}"
         )
-
-        Log.info(f"Rendering adminPanelUsers.html: params: users={users}")
-
         return render_template(
             "adminPanelUsers.html",
-            users=users,
-            page=page,
-            total_pages=total_pages,
+            authors=author_data,
             admin_check=True,
         )
     Log.error(
         f"{request.remote_addr} tried to reach user admin panel without being admin"
     )
     return redirect(f"/login?redirect={request.path}")
-

--- a/app/settings.py
+++ b/app/settings.py
@@ -34,6 +34,8 @@ class Settings:
         DB_POSTS_ROOT (str): Root path of the posts database.
         DB_COMMENTS_ROOT (str): Root path of the comments database.
         DB_ANALYTICS_ROOT (str): Root path of the analytics database.
+        DB_CATEGORIES_ROOT (str): Root path of the categories configuration file.
+        DB_BLACKLIST_ROOT (str): Root path of the blacklist database.
         SMTP_SERVER (str): SMTP server address.
         SMTP_PORT (int): SMTP server port.
         SMTP_MAIL (str): SMTP mail address.
@@ -124,6 +126,7 @@ class Settings:
     DB_COMMENTS_ROOT = DB_FOLDER_ROOT + "comments.db"
     DB_ANALYTICS_ROOT = DB_FOLDER_ROOT + "analytics.db"
     DB_CATEGORIES_ROOT = DB_FOLDER_ROOT + "categories.json"
+    DB_BLACKLIST_ROOT = DB_FOLDER_ROOT + "blacklist.db"
 
     # SMTP Mail Configuration
     SMTP_SERVER = "smtp.gmail.com"

--- a/app/templates/adminPanelUsers.html
+++ b/app/templates/adminPanelUsers.html
@@ -1,82 +1,41 @@
-{% extends 'layout.html' %} {% set admin_check = True %} {% block head %}
+{% extends 'layout.html' %} {% set admin_check = True %}
+{% block head %}
 <title>{{translations.adminPanelUsers.title}}</title>
-{% endblock head %} {% block body %}
+{% endblock head %}
+{% block body %}
 <div class="text-center">
     <h1 class="my-4 text-4xl font-medium select-none">
         {{translations.adminPanelUsers.users}}
     </h1>
 
-    {% for user in users %}
+    {% for author in authors %}
     <div
         class="w-12/12 md:w-8/12 lg:w-7/12 xl:w-5/12 h-fit mx-px md:mx-auto py-2 px-2 my-4 border-2 rounded-md shadow-md border-gray-500/25"
     >
         <section class="mb-4 text-center">
-            <img
-                src="{{ user[4] }}"
-                alt="{{ user[1] }}"
-                class="w-20 m-2 mx-auto select-none"
-            />
             <p class="self-end">
                 <a
-                    href="/user/{{ user[1].lower() }}"
+                    href="/user/{{ author.address|lower }}"
                     class="hover:text-rose-500 duration-150"
-                    >{{ user[1] }}</a
+                    >{{ author.address }}</a
                 >
             </p>
         </section>
 
         <section class="flex w-full justify-between my-4">
             <div class="flex items-center">
-                <i class="ti ti-id mr-1 text-xl"></i>
+                <i class="ti ti-article mr-1 text-xl"></i>
                 <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.id}}:
+                    {{ translations.posts }}:
                 </p>
-                <p class="font-medium">{{ user[0] }}</p>
+                <p class="font-medium">{{ author.posts }}</p>
             </div>
             <div class="flex items-center">
-                <i class="ti ti-user mr-1 text-xl"></i>
+                <i class="ti ti-message mr-1 text-xl"></i>
                 <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.role}}:
+                    {{ translations.comments }}:
                 </p>
-                {% if user[5] == "admin"%}
-                <p class="font-medium">{{translations.roles.admin}}</p>
-                {% elif user[5] == "user"%}
-                <p class="font-medium">{{translations.roles.user}}</p>
-                {% endif %}
-            </div>
-        </section>
-
-        <section class="flex w-full justify-between my-4">
-            <div class="flex items-center text-left text-sm md:text-base">
-                <i class="ti ti-mail mr-1 text-xl"></i>
-                <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.email}}:
-                </p>
-                <p class="break-all font-medium">{{ user[2] }}</p>
-            </div>
-            <div class="flex items-center">
-                <i class="ti ti-sparkles mr-1 text-xl"></i>
-                <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.points}}:
-                </p>
-                <p class="font-medium">{{ user[6] }}</p>
-            </div>
-        </section>
-
-        <section class="flex w-full justify-between my-4">
-            <div class="flex items-center">
-                <i class="ti ti-calendar mr-1 text-xl"></i>
-                <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.joinDate}}:
-                </p>
-                <p class="date font-medium">{{ user[7] }}</p>
-            </div>
-            <div class="flex items-center w-fit">
-                <i class="ti ti-clock mr-1 text-xl"></i>
-                <p class="hidden md:block mr-1">
-                    {{translations.adminPanelUsers.joinTime}}:
-                </p>
-                <p class="time font-medium">{{ user[7] }}</p>
+                <p class="font-medium">{{ author.comments }}</p>
             </div>
         </section>
 
@@ -87,16 +46,14 @@
                     name="csrf_token"
                     value="{{ csrf_token() }}"
                 />
-                <input type="hidden" name="userName" value="{{ user[1] }}" />
+                <input type="hidden" name="address" value="{{ author.address }}" />
                 <button
                     type="submit"
-                    name="userDeleteButton"
+                    name="banButton"
                     class="flex items-center hover:text-rose-500 duration-150 font-medium select-none"
                 >
-                    <i class="ti ti-trash mr-1 text-xl"></i>
-                    <p class="hidden md:block">
-                        {{translations.adminPanelUsers.delete}}
-                    </p>
+                    <i class="ti ti-ban mr-1 text-xl"></i>
+                    <p class="hidden md:block">Ban</p>
                 </button>
             </form>
 
@@ -106,32 +63,20 @@
                     name="csrf_token"
                     value="{{ csrf_token() }}"
                 />
-                <input type="hidden" name="userName" value="{{ user[1] }}" />
+                <input type="hidden" name="address" value="{{ author.address }}" />
                 <button
                     type="submit"
-                    name="userRoleChangeButton"
+                    name="blacklistButton"
                     class="flex items-center hover:text-rose-500 duration-150 font-medium select-none"
                 >
-                    {% if user[5] == "admin" %}
-                    <i class="ti ti-user-down mr-1 text-xl"></i>
-                    <p class="hidden md:block">
-                        {{translations.adminPanelUsers.setUser}}
-                    </p>
-                    {% else %}
-                    <i class="ti ti-user-up mr-1 text-xl"></i>
-                    <p class="hidden md:block">
-                        {{translations.adminPanelUsers.setAdmin}}
-                    </p>
-                    {% endif %}
+                    <i class="ti ti-circle-minus mr-1 text-xl"></i>
+                    <p class="hidden md:block">Blacklist Content</p>
                 </button>
             </form>
         </section>
     </div>
     {% endfor %}
 </div>
-
-{% from "components/pagination.html" import pagination %}
-{{ pagination(page, total_pages, request.path) }}
 
 <a href="/admin" class="hidden md:block fixed bottom-0 left-1">
     <i

--- a/app/utils/blacklist.py
+++ b/app/utils/blacklist.py
@@ -1,0 +1,66 @@
+"""Utilities for blacklisting user content."""
+import sqlite3
+from settings import Settings
+from utils.log import Log
+
+
+class Blacklist:
+    """Helper methods for managing the blacklist database."""
+
+    @staticmethod
+    def add_user_content(user_name: str) -> None:
+        """Add all posts and comments of ``user_name`` to the blacklist table.
+
+        The function collects IDs of posts and comments authored by ``user_name``
+        and stores them in ``Settings.DB_BLACKLIST_ROOT``.
+        """
+        Log.database(f"Connecting to '{Settings.DB_BLACKLIST_ROOT}' database")
+        bl_conn = sqlite3.connect(Settings.DB_BLACKLIST_ROOT)
+        bl_conn.set_trace_callback(Log.database)
+        bl_cur = bl_conn.cursor()
+        bl_cur.execute(
+            """
+            create table if not exists blacklist(
+                id integer primary key autoincrement,
+                type text not null,
+                contentID integer not null
+            )
+            """
+        )
+
+        # Blacklist posts
+        try:
+            conn = sqlite3.connect(Settings.DB_POSTS_ROOT)
+            conn.set_trace_callback(Log.database)
+            cur = conn.cursor()
+            cur.execute("select id from posts where author = ?", (user_name,))
+            for (pid,) in cur.fetchall():
+                bl_cur.execute(
+                    "insert into blacklist(type, contentID) values(?, ?)",
+                    ("post", pid),
+                )
+            conn.close()
+        except Exception as exc:  # pragma: no cover - database may be missing
+            Log.error(f"Blacklist posts failed: {exc}")
+
+        # Blacklist comments
+        try:
+            conn = sqlite3.connect(Settings.DB_COMMENTS_ROOT)
+            conn.set_trace_callback(Log.database)
+            cur = conn.cursor()
+            cur.execute(
+                "select id from comments where lower(user) = ?",
+                (user_name.lower(),),
+            )
+            for (cid,) in cur.fetchall():
+                bl_cur.execute(
+                    "insert into blacklist(type, contentID) values(?, ?)",
+                    ("comment", cid),
+                )
+            conn.close()
+        except Exception as exc:  # pragma: no cover - database may be missing
+            Log.error(f"Blacklist comments failed: {exc}")
+
+        bl_conn.commit()
+        bl_conn.close()
+        Log.success(f'Content for "{user_name}" added to blacklist')

--- a/app/utils/dbChecker.py
+++ b/app/utils/dbChecker.py
@@ -336,3 +336,34 @@ def analyticsTable():
         Log.success(
             f'Table: "postsAnalytics" created in "{Settings.DB_ANALYTICS_ROOT}"'
         )
+
+
+def blacklistTable():
+    """Ensure the blacklist table exists."""
+    if exists(Settings.DB_BLACKLIST_ROOT):
+        Log.info(f'Blacklist database: "{Settings.DB_BLACKLIST_ROOT}" found')
+    else:
+        Log.error(f'Blacklist database: "{Settings.DB_BLACKLIST_ROOT}" not found')
+        open(Settings.DB_BLACKLIST_ROOT, "x")
+        Log.success(f'Blacklist database: "{Settings.DB_BLACKLIST_ROOT}" created')
+
+    Log.database(f"Connecting to '{Settings.DB_BLACKLIST_ROOT}' database")
+    connection = sqlite3.connect(Settings.DB_BLACKLIST_ROOT)
+    connection.set_trace_callback(Log.database)
+    cursor = connection.cursor()
+    try:
+        cursor.execute("select id from blacklist;").fetchall()
+        Log.info(f'Table: "blacklist" found in "{Settings.DB_BLACKLIST_ROOT}"')
+    except Exception:
+        Log.error(f'Table: "blacklist" not found in "{Settings.DB_BLACKLIST_ROOT}"')
+        blacklist_table = """
+        create table if not exists blacklist(
+            "id" integer not null,
+            "type" text,
+            "contentID" integer,
+            primary key("id" autoincrement)
+        );"""
+        cursor.execute(blacklist_table)
+        connection.commit()
+        Log.success(f'Table: "blacklist" created in "{Settings.DB_BLACKLIST_ROOT}"')
+    connection.close()


### PR DESCRIPTION
## Summary
- list unique authors from posts and comments on admin users page
- allow banning users or blacklisting all their content
- create and initialize blacklist database on startup
- ignore generated blacklist database so repository stays free of binaries

## Testing
- `python -m py_compile app/settings.py app/utils/dbChecker.py app/utils/blacklist.py app/routes/adminPanelUsers.py app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6d489608327a22981b99aa10a3e