### PR TITLE
Fix missing templates by configuring Flask directories

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -139,6 +139,8 @@ Log.info("Starting...")
 app = Flask(
     import_name=Settings.APP_NAME,
     root_path=Settings.APP_ROOT_PATH,
+    template_folder="app/templates",
+    static_folder="app/static",
 )
 
 


### PR DESCRIPTION
## Summary
- Configure Flask to load templates and static files from the app directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0ea59e874832781593b47d70435b5