### PR TITLE
feat: add admin posts blacklist option

### DIFF
--- a/app/templates/adminPanelPosts.html
+++ b/app/templates/adminPanelPosts.html
@@ -1,0 +1,51 @@
+{% extends 'layout.html' %}
+{% set admin_check = True %}
+{% block head %}
+<title>{{ translations.dashboard.titleAdmin }}</title>
+{% endblock head %}
+{% block body %}
+<h1 class="my-4 text-4xl font-medium select-none text-center">
+    {{ translations.dashboard.posts }}
+</h1>
+
+{% for post in posts %}
+<div class="w-12/12 md:w-8/12 lg:w-7/12 xl:w-5/12 h-fit mx-px md:mx-auto py-2 px-2 my-4 border-2 rounded-md shadow-md border-gray-500/25">
+    <section class="mb-4 text-center break-words">
+        <a href="/post/{{ post[10] }}" class="text-rose-500 hover:text-rose-500/75 duration-150">
+            {{ post[1] }}
+        </a>
+        <p class="mt-2">
+            {{ translations.dashboard.author }}:
+            <a href="/user/{{ post[5].lower() }}" class="hover:text-rose-500 duration-150">{{ post[5] }}</a>
+        </p>
+    </section>
+
+    <section class="flex w-full justify-between mt-4">
+        <form method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <input type="hidden" name="postID" value="{{ post[0] }}" />
+            <button type="submit" name="postDeleteButton" class="flex items-center hover:text-rose-500 duration-150 font-medium select-none">
+                <i class="ti ti-trash-x mr-1 text-xl"></i>
+                <p class="hidden md:block">Delete</p>
+            </button>
+        </form>
+
+        <form method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <input type="hidden" name="postID" value="{{ post[0] }}" />
+            <button type="submit" name="blacklistButton" class="flex items-center hover:text-rose-500 duration-150 font-medium select-none">
+                <i class="ti ti-circle-minus mr-1 text-xl"></i>
+                <p class="hidden md:block">Blacklist</p>
+            </button>
+        </form>
+    </section>
+</div>
+{% endfor %}
+
+{% from "components/pagination.html" import pagination %}
+{{ pagination(page, total_pages, request.path) }}
+
+<a href="/admin" class="hidden md:block fixed bottom-0 left-1">
+    <i class="ti ti-arrow-back mr-1 text-xl hover:text-rose-500 duration-150"></i>
+</a>
+{% endblock body %}


### PR DESCRIPTION
## Summary
- list posts in admin panel with title and author
- allow deleting or blacklisting posts by storing URL IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0ee509bc883279832ec5a509c9b1f