### PR TITLE
feat: show admin posts with blacklist option

### DIFF
--- a/app/routes/adminPanelPosts.py
+++ b/app/routes/adminPanelPosts.py
@@ -1,10 +1,12 @@
+"""Admin panel for listing and blacklisting posts."""
+
 import sqlite3
+from math import ceil
 
 from flask import Blueprint, redirect, render_template, request, session
 from settings import Settings
-from utils.delete import Delete
 from utils.log import Log
-from utils.paginate import paginate_query
+from web3 import Web3
 
 adminPanelPostsBlueprint = Blueprint("adminPanelPosts", __name__)
 
@@ -14,17 +16,11 @@ adminPanelPostsBlueprint = Blueprint("adminPanelPosts", __name__)
 def adminPanelPosts():
     if "walletAddress" in session and session.get("userRole") == "admin":
         Log.info(f"Admin: {session['walletAddress']} reached to posts admin panel")
-        Log.database(f"Connecting to '{Settings.DB_POSTS_ROOT}' database")
 
+        # Handle blacklist requests
         if request.method == "POST":
             post_id = request.form.get("postID")
-            if "postDeleteButton" in request.form:
-                Log.info(
-                    f"Admin: {session['walletAddress']} deleted post: {post_id}"
-                )
-                Delete.post(post_id)
-                return redirect("/admin/posts")
-            if "blacklistButton" in request.form:
+            if "blacklistButton" in request.form and post_id is not None:
                 Log.info(
                     f"Admin: {session['walletAddress']} blacklisted post: {post_id}"
                 )
@@ -32,34 +28,76 @@ def adminPanelPosts():
                 connection.set_trace_callback(Log.database)
                 cursor = connection.cursor()
                 cursor.execute(
-                    "select urlID from posts where id = ?", (post_id,)
+                    "insert or ignore into deletedPosts(urlID) values(?)",
+                    (post_id,),
                 )
-                row = cursor.fetchone()
-                if row:
-                    cursor.execute(
-                        "insert or ignore into deletedPosts(urlID) values(?)",
-                        (row[0],),
-                    )
-                    connection.commit()
+                connection.commit()
                 connection.close()
                 return redirect("/admin/posts")
 
-        posts, page, total_pages = paginate_query(
-            Settings.DB_POSTS_ROOT,
-            "select count(*) from posts",
-            "select * from posts order by timeStamp desc",
-        )
+        # Fetch existing blacklisted post IDs
+        deleted = set()
+        try:
+            connection = sqlite3.connect(Settings.DB_POSTS_ROOT)
+            connection.set_trace_callback(Log.database)
+            cursor = connection.cursor()
+            cursor.execute("select urlID from deletedPosts")
+            deleted = {row[0] for row in cursor.fetchall()}
+            connection.close()
+        except Exception as exc:  # pragma: no cover - database may be missing
+            Log.error(f"Fetching deleted posts failed: {exc}")
+
+        # Gather posts from blockchain
+        posts = []
+        try:  # pragma: no cover - external calls
+            w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
+            contract_info = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
+            contract = w3.eth.contract(
+                address=contract_info["address"], abi=contract_info["abi"]
+            )
+            next_id = contract.functions.nextPostId().call()
+            for pid in range(next_id - 1, -1, -1):
+                data = contract.functions.posts(pid).call()
+                author = data[0]
+                content_hash = data[1]
+                exists = data[4]
+                blacklisted = data[5]
+                banner_id = data[7]
+                if not exists or blacklisted or str(pid) in deleted:
+                    continue
+                title = content_hash.split("|", 1)[0] if content_hash else ""
+                posts.append(
+                    {
+                        "id": pid,
+                        "title": title,
+                        "author": author,
+                        "banner": banner_id,
+                    }
+                )
+        except Exception as exc:  # pragma: no cover - network errors
+            Log.error(f"Fetching posts from blockchain failed: {exc}")
+
+        # Paginate posts
+        page = request.args.get("page", 1, type=int)
+        per_page = 9
+        total_pages = max(ceil(len(posts) / per_page), 1)
+        start = (page - 1) * per_page
+        posts = posts[start : start + per_page]
 
         Log.info(
             f"Rendering adminPanelPosts.html: params: posts={len(posts)}"
         )
 
+        post_contract = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
         return render_template(
             "adminPanelPosts.html",
             posts=posts,
             page=page,
             total_pages=total_pages,
             admin_check=True,
+            post_contract_address=post_contract["address"],
+            post_contract_abi=post_contract["abi"],
+            rpc_url=Settings.BLOCKCHAIN_RPC_URL,
         )
     Log.error(
         f"{request.remote_addr} tried to reach post admin panel without being admin"

--- a/app/templates/adminPanelPosts.html
+++ b/app/templates/adminPanelPosts.html
@@ -10,29 +10,26 @@
 
 {% for post in posts %}
 <div class="w-12/12 md:w-8/12 lg:w-7/12 xl:w-5/12 h-fit mx-px md:mx-auto py-2 px-2 my-4 border-2 rounded-md shadow-md border-gray-500/25">
+    <img
+        data-magnet-id="{{ post.banner }}"
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+        alt="{{ post.title }}"
+        class="w-full rounded-md mb-4"
+    />
     <section class="mb-4 text-center break-words">
-        <a href="/post/{{ post[10] }}" class="text-rose-500 hover:text-rose-500/75 duration-150">
-            {{ post[1] }}
+        <a href="/post/{{ post.id }}" class="text-rose-500 hover:text-rose-500/75 duration-150">
+            {{ post.title }}
         </a>
         <p class="mt-2">
             {{ translations.dashboard.author }}:
-            <a href="/user/{{ post[5].lower() }}" class="hover:text-rose-500 duration-150">{{ post[5] }}</a>
+            <a href="/user/{{ post.author.lower() }}" class="hover:text-rose-500 duration-150">{{ post.author }}</a>
         </p>
     </section>
 
-    <section class="flex w-full justify-between mt-4">
+    <section class="flex w-full justify-center mt-4">
         <form method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="postID" value="{{ post[0] }}" />
-            <button type="submit" name="postDeleteButton" class="flex items-center hover:text-rose-500 duration-150 font-medium select-none">
-                <i class="ti ti-trash-x mr-1 text-xl"></i>
-                <p class="hidden md:block">Delete</p>
-            </button>
-        </form>
-
-        <form method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="postID" value="{{ post[0] }}" />
+            <input type="hidden" name="postID" value="{{ post.id }}" />
             <button type="submit" name="blacklistButton" class="flex items-center hover:text-rose-500 duration-150 font-medium select-none">
                 <i class="ti ti-circle-minus mr-1 text-xl"></i>
                 <p class="hidden md:block">Blacklist</p>


### PR DESCRIPTION
## Summary
- Fetch posts from blockchain and display in admin panel
- Show banner, title, and author for each post
- Allow blacklisting posts by storing their IDs in deletedPosts table

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0efa59d188327a6347f33dc9a7613