### PR TITLE
Fix admin posts banner index error

### DIFF
--- a/app/routes/adminPanelPosts.py
+++ b/app/routes/adminPanelPosts.py
@@ -62,7 +62,7 @@ def adminPanelPosts():
                 content_hash = data[1]
                 exists = data[4]
                 blacklisted = data[5]
-                banner_id = data[7]
+                banner_id = data[6]
                 if not exists or blacklisted or str(pid) in deleted:
                     continue
                 title = content_hash.split("|", 1)[0] if content_hash else ""


### PR DESCRIPTION
## Summary
- Correct banner ID index when retrieving posts from PostStorage

## Testing
- `python -m py_compile app/routes/adminPanelPosts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1365a0c8327b47550ebb127de6a