### PR TITLE
Add comment blacklist handling

### DIFF
--- a/app/routes/adminPanelUsers.py
+++ b/app/routes/adminPanelUsers.py
@@ -55,7 +55,9 @@ def adminPanelUsers():
             connection = sqlite3.connect(Settings.DB_COMMENTS_ROOT)
             connection.set_trace_callback(Log.database)
             cursor = connection.cursor()
-            cursor.execute("select user from comments")
+            cursor.execute(
+                "select user from comments where id not in (select commentID from deletedComments)"
+            )
             for (addr,) in cursor.fetchall():
                 authors[addr]["comments"] += 1
             connection.close()

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -43,7 +43,7 @@ def dashboard(userName):
             cursor = connection.cursor()
 
             cursor.execute(
-                """select * from comments where lower(user) = ? order by timeStamp desc""",
+                """select * from comments where lower(user) = ? and id not in (select commentID from deletedComments) order by timeStamp desc""",
                 [(userName.lower())],
             )
             comments = cursor.fetchall()

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -61,7 +61,7 @@ def user(userName):
         connection.set_trace_callback(Log.database)
         cursor = connection.cursor()
         cursor.execute(
-            """select * from comments where lower(user) = ? """,
+            """select * from comments where lower(user) = ? and id not in (select commentID from deletedComments) """,
             [(userName.lower())],
         )
         comments = cursor.fetchall()

--- a/app/templates/adminPanelComments.html
+++ b/app/templates/adminPanelComments.html
@@ -68,7 +68,7 @@
                 />
                 <button
                     type="submit"
-                    name="commentDeleteButton"
+                    name="blacklistButton"
                     class="hover:text-rose-500 duration-150 font-medium"
                 >
                     <i class="ti ti-trash-x mr-1 text-2xl"></i>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -64,6 +64,7 @@
 </div>
 <script>
     const postUrlID = {{ id }};
+    window.blacklistedComments = {{ blacklisted_comments | tojson }};
 </script>
 {% endblock body %}
 

--- a/app/utils/dbChecker.py
+++ b/app/utils/dbChecker.py
@@ -279,6 +279,19 @@ def commentsTable():
         connection.commit()
         Log.success(f'Table: "commentVotes" created in "{Settings.DB_COMMENTS_ROOT}"')
 
+    # Ensure deletedComments table exists
+    try:
+        cursor.execute("""select commentID from deletedComments limit 1""")
+    except Exception:
+        deletedCommentsTable = """
+        create table if not exists deletedComments(
+            "commentID" integer not null unique
+        );"""
+
+        cursor.execute(deletedCommentsTable)
+        connection.commit()
+        Log.success(f'Table: "deletedComments" created in "{Settings.DB_COMMENTS_ROOT}"')
+
     connection.close()
 
 

--- a/app/utils/delete.py
+++ b/app/utils/delete.py
@@ -162,6 +162,10 @@ class Delete:
             [(commentID)],
         )
         cursor.execute(
+            """insert or ignore into deletedComments(commentID) values(?)""",
+            (commentID,),
+        )
+        cursor.execute(
             """delete from comments where id = ? """,
             [(commentID)],
         )


### PR DESCRIPTION
## Summary
- Add `deletedComments` table and record comment removals
- Filter locally blacklisted comments from admin, comment tree, and front-end rendering
- List admin comments chronologically

## Testing
- `pytest`
- `python -m py_compile app/routes/adminPanelComments.py app/routes/adminPanelUsers.py app/routes/dashboard.py app/routes/post.py app/routes/user.py app/utils/dbChecker.py app/utils/delete.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f2bfd2988327a1f8a869c156a3ff