### PR TITLE
fix: avoid debug crash when comments page loads

### DIFF
--- a/app/static/js/comments.js
+++ b/app/static/js/comments.js
@@ -1,5 +1,8 @@
 (() => {
-  const debug = (...args) => window.debugLog('comments.js', ...args);
+  const debug = (...args) =>
+    (window.debugLog
+      ? window.debugLog('comments.js', ...args)
+      : console.log('comments.js', ...args));
   debug('Loaded');
 
   async function init() {


### PR DESCRIPTION
## Summary
- prevent comments.js from crashing if `window.debugLog` is undefined

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f438caa48327b41fe15ac6cb4321