### PR TITLE
feat: dynamic admin contract interface

### DIFF
--- a/app/routes/adminPanelContracts.py
+++ b/app/routes/adminPanelContracts.py
@@ -21,6 +21,7 @@ def adminPanelContracts():
             "adminPanelContracts.html",
             contracts=Settings.BLOCKCHAIN_CONTRACTS,
             admin_check=True,
+            rpc_url=Settings.BLOCKCHAIN_RPC_URL,
         )
     Log.error(
         f"{request.remote_addr} tried to reach contracts admin panel without being admin"

--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -1,0 +1,93 @@
+(() => {
+    const debug = (...args) => window.debugLog('adminContracts.js', ...args);
+    debug('Loaded');
+
+    const contracts = window.contractsData || {};
+    if (!Object.keys(contracts).length || typeof ethers === 'undefined') {
+        debug('No contracts or ethers not loaded');
+        return;
+    }
+
+    const provider = window.ethereum
+        ? new ethers.providers.Web3Provider(window.ethereum)
+        : new ethers.providers.JsonRpcProvider(window.rpcUrl || '');
+
+    let signer;
+    async function getSigner() {
+        if (!signer) {
+            if (!window.ethereum) {
+                throw new Error('No wallet available');
+            }
+            await provider.send('eth_requestAccounts', []);
+            signer = provider.getSigner();
+        }
+        return signer;
+    }
+
+    Object.entries(contracts).forEach(([name, info]) => {
+        const container = document.getElementById(`functions-${name}`);
+        if (!container) return;
+        const contract = new ethers.Contract(info.address, info.abi, provider);
+
+        info.abi
+            .filter((item) => item.type === 'function')
+            .forEach((fn) => {
+                const fnDiv = document.createElement('div');
+                fnDiv.className = 'my-2';
+
+                const title = document.createElement('p');
+                title.textContent = fn.name;
+                title.className = 'font-medium';
+                fnDiv.appendChild(title);
+
+                const form = document.createElement('form');
+                form.className = 'flex flex-col items-center';
+
+                fn.inputs.forEach((input, idx) => {
+                    const inp = document.createElement('input');
+                    inp.className = 'input input-bordered mb-2';
+                    inp.placeholder = input.name || input.type;
+                    inp.name = `arg${idx}`;
+                    form.appendChild(inp);
+                });
+
+                const button = document.createElement('button');
+                button.type = 'submit';
+                button.className = 'btn btn-sm btn-neutral';
+                const isReadOnly =
+                    fn.stateMutability === 'view' || fn.stateMutability === 'pure';
+                button.textContent = isReadOnly ? 'Call' : 'Send';
+                form.appendChild(button);
+
+                const result = document.createElement('div');
+                result.className = 'mt-2 text-sm break-words';
+                form.appendChild(result);
+
+                form.addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    const args = fn.inputs.map((_, idx) => form[`arg${idx}`].value);
+                    try {
+                        if (isReadOnly) {
+                            const res = await contract[fn.name](...args);
+                            result.textContent = Array.isArray(res)
+                                ? JSON.stringify(res)
+                                : res?.toString();
+                        } else {
+                            const s = await getSigner();
+                            const c = contract.connect(s);
+                            const tx = await c[fn.name](...args);
+                            result.textContent = `Tx: ${tx.hash}`;
+                            await tx.wait();
+                            result.textContent = `Success: ${tx.hash}`;
+                        }
+                    } catch (err) {
+                        debug('Function call failed', err);
+                        result.textContent = `Error: ${err.message || err}`;
+                    }
+                });
+
+                fnDiv.appendChild(form);
+                container.appendChild(fnDiv);
+            });
+    });
+})();

--- a/app/templates/adminPanelContracts.html
+++ b/app/templates/adminPanelContracts.html
@@ -27,34 +27,17 @@
                 <i class="ti ti-device-floppy mr-1 text-2xl"></i>
             </button>
         </form>
-        <form method="post" class="flex items-center justify-center mt-2">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-            <input type="hidden" name="contractName" value="{{ name }}" />
-            <input
-                type="text"
-                name="contractMethod"
-                placeholder="method"
-                class="input input-bordered mr-2"
-            />
-            <input
-                type="text"
-                name="contractArgs"
-                placeholder='["arg1",123]'
-                class="input input-bordered mr-2"
-            />
-            <button
-                type="submit"
-                name="contractCallButton"
-                class="hover:text-rose-500 duration-150 font-medium"
-            >
-                <i class="ti ti-terminal mr-1 text-2xl"></i>
-            </button>
-        </form>
+        <div id="functions-{{ name }}" class="mt-4"></div>
     </div>
     {% endfor %}
 </div>
 <a href="/admin" class="hidden md:block fixed bottom-0 left-1">
     <i class="ti ti-arrow-back mr-1 text-xl hover:text-rose-500 duration-150"></i>
 </a>
+<script>
+    window.contractsData = {{ contracts | tojson }};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+<script src="{{ url_for('static', filename='js/adminContracts.js') }}"></script>
 {% endblock body %}
 


### PR DESCRIPTION
## Summary
- dynamically render admin contract functions from ABI
- add client-side script for calling read-only and transaction methods
- expose RPC URL to contract admin route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f6767b248327a0bf165cccf918fc