### PR TITLE
Allow WebTorrent tracker in CSP

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -259,7 +259,7 @@ def afterRequest(response):
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com; "
         "img-src 'self' data: https: blob:; "
         "font-src 'self' https://cdn.jsdelivr.net; "
-        "connect-src 'self' https://mainnet.era.zksync.io wss://tracker.btorrent.xyz wss://tracker.openwebtorrent.com;"
+        "connect-src 'self' https://mainnet.era.zksync.io wss://tracker.btorrent.xyz wss://tracker.openwebtorrent.com wss://tracker.webtorrent.dev;"
     )
     return response
 


### PR DESCRIPTION
## Summary
- Permit `wss://tracker.webtorrent.dev` in Content Security Policy

## Testing
- `cd app && python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f8784bac832784e8131a6c69d4fb