### PR TITLE
Seed images from app directory and keep webtorrent running

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -153,7 +153,7 @@ app.config["SESSION_PERMANENT"] = Settings.SESSION_PERMANENT
 
 csrf = CSRFProtect(app)
 
-images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+images_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
 ensure_seeding(images_dir)
 
 

--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -21,7 +21,7 @@ def createPost():
         if not image or image.filename == "":
             return jsonify({"error": "no image supplied"}), 400
 
-        images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+        images_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
         os.makedirs(images_dir, exist_ok=True)
         filename = secure_filename(image.filename)
         image_path = os.path.join(images_dir, filename)
@@ -62,7 +62,7 @@ def upload_media():
     if not file or file.filename == "":
         return jsonify({"error": "no file supplied"}), 400
 
-    media_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+    media_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
     os.makedirs(media_dir, exist_ok=True)
     filename = secure_filename(file.filename)
     media_path = os.path.join(media_dir, filename)
@@ -79,7 +79,7 @@ def delete_media():
     filename = request.form.get("filename")
     if not filename:
         return jsonify({"error": "no filename supplied"}), 400
-    media_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+    media_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
     file_path = os.path.join(media_dir, secure_filename(filename))
     if os.path.exists(file_path):
         os.remove(file_path)

--- a/app/routes/editPost.py
+++ b/app/routes/editPost.py
@@ -152,7 +152,7 @@ def editPost(urlID):
                             (postCategory, post[0]),
                         )
                         if postBanner != b"":
-                            images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+                            images_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
                             os.makedirs(images_dir, exist_ok=True)
                             image_path = os.path.join(images_dir, f"{post[0]}.png")
                             with open(image_path, "wb") as f:

--- a/app/utils/torrent_worker.py
+++ b/app/utils/torrent_worker.py
@@ -13,7 +13,14 @@ def seed(file_path: str) -> None:
 
     save_path = os.path.dirname(os.path.abspath(file_path)) or os.getcwd()
 
-    cmd = ["webtorrent", "seed", file_path, "--out", save_path]
+    cmd = [
+        "webtorrent",
+        "seed",
+        file_path,
+        "--keep-seeding",
+        "--out",
+        save_path,
+    ]
 
     # Capture output so we can forward the magnet URI to the parent process.
     proc = subprocess.Popen(


### PR DESCRIPTION
## Summary
- Keep torrents alive by adding `--keep-seeding` to webtorrent worker
- Store and seed uploaded media from dedicated `app/images` directory across the app

## Testing
- `python -m py_compile app/app.py app/routes/createPost.py app/routes/editPost.py app/utils/torrent_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0ff2a3f4883278281741d0459e400