### PR TITLE
Track post analytics for read time and viewer activity

### DIFF
--- a/app/static/js/postActivity.js
+++ b/app/static/js/postActivity.js
@@ -3,6 +3,18 @@
     debug('Loaded');
     if (typeof postUrlID === 'undefined') return;
     let start = Date.now();
+    async function loadStats() {
+        try {
+            const res = await fetch(`/api/v1/postStats?postID=${postUrlID}`);
+            if (!res.ok) return;
+            const data = await res.json();
+            const el = document.getElementById('reading-time');
+            if (el && data.estimatedReadTime) el.textContent = data.estimatedReadTime;
+        } catch (e) {
+            debug('Failed to load stats', e);
+        }
+    }
+    loadStats();
     function send(action, extra = {}) {
         fetch('/api/v1/postStats/activity', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- Persist reading-time estimate to analytics store when serving posts
- Fetch post statistics on post pages and update the displayed reading time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b102abad8c8327aa6a0e08e515158d