### PR TITLE
Fix post stats activity endpoint 400 CSRF error

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -152,6 +152,7 @@ app.config["SESSION_PERMANENT"] = Settings.SESSION_PERMANENT
 
 
 csrf = CSRFProtect(app)
+csrf.exempt(postStatsBlueprint)
 
 images_dir = os.path.join(Settings.APP_ROOT_PATH, "app", "images")
 ensure_seeding(images_dir)


### PR DESCRIPTION
## Summary
- exempt `postStats` API routes from CSRF protection to allow activity reporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b108313c6c8327b408f05bf8e76862