### PR TITLE
chore: update Mumble server address

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,7 +28,7 @@
 
 <div class="flex justify-center gap-4 mt-4">
     <a
-        href="mumble://q3bzznjvg5w67ookosiskiansjbck3nclcqzyvoh42t3afq3ittbgaid.onion:64738"
+        href="mumble://158.69.201.35:64738"
         target="_blank"
         rel="noopener noreferrer"
     >


### PR DESCRIPTION
## Summary
- point Mumble client link to 158.69.201.35 instead of Tor hidden service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b11ef68b0c83278f1686d792dce34d