### PR TITLE
Show post tile metrics for all users and log user activity

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -31,6 +31,9 @@ from routes.adminPanelPosts import (
 from routes.adminPanelUsers import (
     adminPanelUsersBlueprint,
 )
+from routes.adminPanelActivity import (
+    adminPanelActivityBlueprint,
+)
 from routes.category import (
     categoryBlueprint,
 )
@@ -296,6 +299,7 @@ app.register_blueprint(changeProfilePictureBlueprint)
 app.register_blueprint(analyticsBlueprint)
 app.register_blueprint(returnPostAnalyticsDataBlueprint)
 app.register_blueprint(postStatsBlueprint)
+app.register_blueprint(adminPanelActivityBlueprint)
 app.register_blueprint(commentsBlueprint)
 
 

--- a/app/routes/adminPanelActivity.py
+++ b/app/routes/adminPanelActivity.py
@@ -1,0 +1,42 @@
+import sqlite3
+from datetime import datetime
+
+from flask import Blueprint, render_template, request, session
+from settings import Settings
+from utils.log import Log
+
+adminPanelActivityBlueprint = Blueprint("adminPanelActivity", __name__)
+
+
+@adminPanelActivityBlueprint.route("/admin/activity")
+def adminPanelActivity():
+    if "walletAddress" in session and session.get("userRole") == "admin":
+        Log.info(f"Admin: {session['walletAddress']} reached to activity admin panel")
+        with sqlite3.connect(Settings.DB_ANALYTICS_ROOT) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT ip, country, path, method, userName, timeStamp
+                FROM userActivity
+                ORDER BY timeStamp DESC
+                LIMIT 100
+                """
+            ).fetchall()
+        activities = [
+            {
+                "ip": r["ip"],
+                "country": r["country"],
+                "path": r["path"],
+                "method": r["method"],
+                "userName": r["userName"],
+                "time": datetime.utcfromtimestamp(r["timeStamp"]).strftime("%Y-%m-%d %H:%M:%S"),
+            }
+            for r in rows
+        ]
+        return render_template(
+            "adminPanelActivity.html", activities=activities, admin_check=True
+        )
+    Log.error(
+        f"{request.remote_addr} tried to reach activity admin panel without being admin"
+    )
+    return render_template("notFound.html")

--- a/app/routes/postStats.py
+++ b/app/routes/postStats.py
@@ -42,8 +42,6 @@ def get_post_stats():
                 "SELECT * FROM postStats WHERE postID=?", (post_id,)
             ).fetchone()
     data = dict(row)
-    if session.get("userRole") != "admin":
-        data = {"postID": data["postID"], "estimatedReadTime": data["estimatedReadTime"]}
     return jsonify(data)
 
 

--- a/app/templates/adminPanel.html
+++ b/app/templates/adminPanel.html
@@ -22,15 +22,25 @@
         </a>
     </h1>
 
-    <h1 class="my-4">
-        <a
-            href="admin/analytics"
-            class="hover:text-rose-500 duration-150 flex items-center w-fit mx-auto"
-        >
-            <i class="ti ti-chart-bar mr-1 text-2xl"></i> {{
-            translations.adminPanel.analytics | default('Analytics') }}
-        </a>
-    </h1>
+      <h1 class="my-4">
+          <a
+              href="admin/analytics"
+              class="hover:text-rose-500 duration-150 flex items-center w-fit mx-auto"
+          >
+              <i class="ti ti-chart-bar mr-1 text-2xl"></i> {{
+              translations.adminPanel.analytics | default('Analytics') }}
+          </a>
+      </h1>
+
+      <h1 class="my-4">
+          <a
+              href="admin/activity"
+              class="hover:text-rose-500 duration-150 flex items-center w-fit mx-auto"
+          >
+              <i class="ti ti-list-details mr-1 text-2xl"></i> {{
+              translations.adminPanel.activity | default('Activity') }}
+          </a>
+      </h1>
 
     <h1 class="my-4">
         <a

--- a/app/templates/adminPanelActivity.html
+++ b/app/templates/adminPanelActivity.html
@@ -1,0 +1,38 @@
+{% extends 'layout.html' %} {% set admin_check = True %}
+{% block head %}
+<title>Activity</title>
+{% endblock head %}
+{% block body %}
+<div class="text-center">
+    <h1 class="my-4 text-4xl font-medium select-none">User Activity</h1>
+    <div class="overflow-x-auto">
+        <table class="table-auto w-full max-w-5xl mx-auto text-left text-sm">
+            <thead>
+                <tr>
+                    <th class="px-2">Time</th>
+                    <th class="px-2">IP</th>
+                    <th class="px-2">Country</th>
+                    <th class="px-2">User</th>
+                    <th class="px-2">Method</th>
+                    <th class="px-2">Path</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for a in activities %}
+                <tr class="border-t">
+                    <td class="px-2 py-1">{{ a.time }}</td>
+                    <td class="px-2 py-1">{{ a.ip }}</td>
+                    <td class="px-2 py-1">{{ a.country }}</td>
+                    <td class="px-2 py-1">{{ a.userName or 'Anonymous' }}</td>
+                    <td class="px-2 py-1">{{ a.method }}</td>
+                    <td class="px-2 py-1">{{ a.path }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+<a href="/admin" class="hidden md:block fixed bottom-0 left-1">
+    <i class="ti ti-arrow-back mr-1 text-xl hover:text-rose-500 duration-150"></i>
+</a>
+{% endblock body %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -80,9 +80,7 @@
 {% endblock body %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
-<script src="{{ url_for('static', filename='js/loadPosts.js') }}"></script>
-{% if session.get('userRole') == 'admin' %}
-<script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
-{% endif %}
-{% endblock scripts %}
+  <script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/loadPosts.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
+  {% endblock scripts %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -53,8 +53,6 @@
 {% endblock body %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
-{% if session.get('userRole') == 'admin' %}
-<script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
-{% endif %}
-{% endblock scripts %}
+  <script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
+  {% endblock scripts %}

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -140,8 +140,6 @@
 {% endblock body %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
-{% if session.get('userRole') == 'admin' %}
-<script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
-{% endif %}
-{% endblock scripts %}
+  <script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
+  {% endblock scripts %}

--- a/app/utils/afterRequest.py
+++ b/app/utils/afterRequest.py
@@ -1,5 +1,43 @@
-from flask import request
+import os
+import sqlite3
+import time
+
+from flask import request, session
+from geoip2 import database, errors
 from utils.log import Log
+from settings import Settings
+
+_reader = None
+
+
+def _get_reader():
+    global _reader
+    if _reader is None:
+        db_path = os.path.join(
+            Settings.APP_ROOT_PATH, "static", "geoIP2database", "dbip-country-lite-2025-02.mmdb"
+        )
+        if os.path.exists(db_path):
+            try:
+                _reader = database.Reader(db_path)
+            except Exception as exc:  # pragma: no cover - defensive
+                Log.error(f"GeoIP load failed: {exc}")
+                _reader = None
+        else:
+            _reader = None
+    return _reader
+
+
+def _lookup_country(ip: str) -> str:
+    reader = _get_reader()
+    if not reader:
+        return "Unknown"
+    try:
+        return reader.country(ip).country.name or "Unknown"
+    except errors.AddressNotFoundError:
+        return "Unknown"
+    except Exception as exc:  # pragma: no cover - defensive
+        Log.error(f"GeoIP lookup failed: {exc}")
+        return "Unknown"
 
 
 def afterRequestLogger(response):
@@ -13,17 +51,43 @@ def afterRequestLogger(response):
         Response: The response object returned by the HTTP request.
     """
 
+    message = (
+        f"Adress: {request.remote_addr} | Method: {request.method} | Path: {request.path} | "
+        f"Scheme: {request.scheme} | Status: {response.status} | Content Length: {response.content_length} | "
+        f"Referrer: {request.referrer} | User Agent: {request.user_agent}"
+    )
     if response.status == "200 OK":
-        Log.success(
-            f"Adress: {request.remote_addr} | Method: {request.method} | Path: {request.path} | Scheme: {request.scheme} | Status: {response.status} | Content Length: {response.content_length} | Referrer: {request.referrer} | User Agent: {request.user_agent}",
-        )
+        Log.success(message)
     elif response.status == "404 NOT FOUND":
-        Log.error(
-            f"Adress: {request.remote_addr} | Method: {request.method} | Path: {request.path} | Scheme: {request.scheme} | Status: {response.status} | Content Length: {response.content_length} | Referrer: {request.referrer} | User Agent: {request.user_agent}",
-        )
+        Log.error(message)
     else:
-        Log.info(
-            f"Adress: {request.remote_addr} | Method: {request.method} | Path: {request.path} | Scheme: {request.scheme} | Status: {response.status} | Content Length: {response.content_length} | Referrer: {request.referrer} | User Agent: {request.user_agent}",
-        )
+        Log.info(message)
+
+    ip = request.remote_addr or "Unknown"
+    country = _lookup_country(ip)
+    user = session.get("walletAddress")
+    time_stamp = int(time.time())
+    try:
+        with sqlite3.connect(Settings.DB_ANALYTICS_ROOT) as conn:
+            conn.execute(
+                """
+                create table if not exists userActivity(
+                    id integer primary key autoincrement,
+                    ip text,
+                    path text,
+                    method text,
+                    country text,
+                    userName text,
+                    timeStamp integer
+                )
+                """
+            )
+            conn.execute(
+                "insert into userActivity(ip, path, method, country, userName, timeStamp) values (?, ?, ?, ?, ?, ?)",
+                (ip, request.path, request.method, country, user, time_stamp),
+            )
+            conn.commit()
+    except Exception as exc:  # pragma: no cover - analytics is optional
+        Log.error(f"Failed to log user activity: {exc}")
 
     return response

--- a/app/utils/dbChecker.py
+++ b/app/utils/dbChecker.py
@@ -317,17 +317,16 @@ def analyticsTable():
     connection.set_trace_callback(Log.database)
     cursor = connection.cursor()
     try:
-        cursor.execute("""select id from postsAnalytics; """).fetchall()
-
-        Log.info(f'Table: "postsAnalytics" found in "{Settings.DB_ANALYTICS_ROOT}"')
-
-        connection.close()
+        cursor.execute("select id from postsAnalytics;").fetchall()
+        Log.info(
+            f'Table: "postsAnalytics" found in "{Settings.DB_ANALYTICS_ROOT}"'
+        )
     except Exception:
         Log.error(
             f'Table: "postsAnalytics" not found in "{Settings.DB_ANALYTICS_ROOT}"'
         )
-
-        analyticsTable = """
+        cursor.execute(
+            """
         create table if not exists postsAnalytics(
             "id"    integer not null,
             "postID"  integer,
@@ -339,16 +338,40 @@ def analyticsTable():
             "timeStamp" integer,
             primary key("id" autoincrement)
         );"""
-
-        cursor.execute(analyticsTable)
-
+        )
         connection.commit()
-
-        connection.close()
-
         Log.success(
             f'Table: "postsAnalytics" created in "{Settings.DB_ANALYTICS_ROOT}"'
         )
+
+    try:
+        cursor.execute("select id from userActivity;").fetchall()
+        Log.info(
+            f'Table: "userActivity" found in "{Settings.DB_ANALYTICS_ROOT}"'
+        )
+    except Exception:
+        Log.error(
+            f'Table: "userActivity" not found in "{Settings.DB_ANALYTICS_ROOT}"'
+        )
+        cursor.execute(
+            """
+        create table if not exists userActivity(
+            "id" integer not null,
+            "ip" text,
+            "path" text,
+            "method" text,
+            "country" text,
+            "userName" text,
+            "timeStamp" integer,
+            primary key("id" autoincrement)
+        );"""
+        )
+        connection.commit()
+        Log.success(
+            f'Table: "userActivity" created in "{Settings.DB_ANALYTICS_ROOT}"'
+        )
+
+    connection.close()
 
 
 def blacklistTable():


### PR DESCRIPTION
## Summary
- Always return full post statistics from `/api/v1/postStats`
- Load `postStats.js` on index, user and search pages for everyone
- Record each request's IP, path and country in a `userActivity` table
- Add an Activity view to the admin panel listing recent user actions

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b2324868c48327b13469bf83da7bb8