### PR TITLE
Log real analytics data from post views

### DIFF
--- a/app/static/js/postsAnalytics.js
+++ b/app/static/js/postsAnalytics.js
@@ -21,8 +21,33 @@ let postAnalyticsDataTrafficGraphUrl =
 let lineChartSpinner = document.getElementById("lineChartSpinner");
 lineChartSpinner.classList.remove("hidden");
 let lineChartErrorContainer = document.getElementById(
-  "lineChartErrorContainer",
+  "lineChartErrorContainer"
 );
+const postStatsUrl = "/api/v1/postAnalyticsStats?postID=" + postID;
+
+async function fetchPostStats() {
+  debug('fetchPostStats');
+  try {
+    const res = await fetch(postStatsUrl);
+    const data = await res.json();
+    if (res.ok) {
+      const payload = data.payload || {};
+      const setText = (id, value) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = value;
+      };
+      setText('totalVisitor', payload.totalVisitor);
+      setText('todaysVisitor', payload.todaysVisitor);
+    } else {
+      debug('fetchPostStats error', data.message);
+    }
+  } catch (err) {
+    debug('fetchPostStats exception', err);
+  }
+}
+
+fetchPostStats();
+setInterval(fetchPostStats, 5000);
 
 function startDropDownMenu() {
   debug('startDropDownMenu');
@@ -38,7 +63,7 @@ let durationRangeMap = {
   last1m: "weeks=4",
   last7d: "days=7",
   last24h: "hours=24",
-  last48: "hours=48",
+  last48h: "hours=48",
 };
 
 function durationRangeCallback() {
@@ -350,4 +375,6 @@ async function onViewAllClick() {
 }
 
   loadBarChart("viewAll=False");
+  window.onViewAllClick = onViewAllClick;
+  window.changeTabState = changeTabState;
 })();

--- a/app/static/js/siteAnalytics.js
+++ b/app/static/js/siteAnalytics.js
@@ -21,6 +21,34 @@
   lineChartSpinner.classList.remove("hidden");
   let lineChartErrorContainer = document.getElementById("lineChartErrorContainer");
 
+  const siteStatsUrl = "/api/v1/siteStats";
+
+  async function fetchSiteStats() {
+    debug('fetchSiteStats');
+    try {
+      const res = await fetch(siteStatsUrl);
+      const data = await res.json();
+      if (res.ok) {
+        const payload = data.payload || {};
+        const setText = (id, value) => {
+          const el = document.getElementById(id);
+          if (el) el.textContent = value;
+        };
+        setText('totalVisitor', payload.totalVisitor);
+        setText('todaysVisitor', payload.todaysVisitor);
+        setText('totalPosts', payload.totalPosts);
+        setText('totalComments', payload.totalComments);
+      } else {
+        debug('fetchSiteStats error', data.message);
+      }
+    } catch (err) {
+      debug('fetchSiteStats exception', err);
+    }
+  }
+
+  fetchSiteStats();
+  setInterval(fetchSiteStats, 5000);
+
   function startDropDownMenu() {
     debug('startDropDownMenu');
     document
@@ -30,13 +58,13 @@
 
   window.addEventListener("load", startDropDownMenu, false);
 
-  let durationRangeMap = {
-    sincePosted: "sincePosted=True",
-    last1m: "weeks=4",
-    last7d: "days=7",
-    last24h: "hours=24",
-    last48: "hours=48",
-  };
+    let durationRangeMap = {
+      sincePosted: "sincePosted=True",
+      last1m: "weeks=4",
+      last7d: "days=7",
+      last24h: "hours=24",
+      last48h: "hours=48",
+    };
 
   function durationRangeCallback() {
     let selectedDurationRange = document.getElementById("durationRangeTab").value;

--- a/app/templates/postsAnalytics.html
+++ b/app/templates/postsAnalytics.html
@@ -51,6 +51,7 @@
                 </dt>
 
                 <dd
+                    id="totalVisitor"
                     class="text-4xl font-extrabold text-rose-500/75 md:text-5xl"
                 >
                     {{ post[6] }}
@@ -65,6 +66,7 @@
                 </dt>
 
                 <dd
+                    id="todaysVisitor"
                     class="text-4xl font-extrabold text-rose-500/75 md:text-5xl"
                 >
                     {{ todaysVisitor }}

--- a/app/templates/siteAnalytics.html
+++ b/app/templates/siteAnalytics.html
@@ -14,19 +14,19 @@
         <dl class="mt-6 grid grid-cols-1 gap-4 sm:mt-8 sm:grid-cols-2 lg:grid-cols-4">
             <div class="flex flex-col rounded-lg bg-rose-50 px-4 py-8 text-center">
                 <dt class="order-last text-lg font-medium text-gray-500">{{ translations.analytics.totalVisitor }}</dt>
-                <dd class="text-4xl font-extrabold text-rose-500/75 md:text-5xl">{{ totalVisitor }}</dd>
+                <dd id="totalVisitor" class="text-4xl font-extrabold text-rose-500/75 md:text-5xl">{{ totalVisitor }}</dd>
             </div>
             <div class="flex flex-col rounded-lg bg-rose-50 px-4 py-8 text-center">
                 <dt class="order-last text-lg font-medium text-gray-500">{{ translations.analytics.todaysVisitor }}</dt>
-                <dd class="text-4xl font-extrabold text-rose-500/75 md:text-5xl">{{ todaysVisitor }}</dd>
+                <dd id="todaysVisitor" class="text-4xl font-extrabold text-rose-500/75 md:text-5xl">{{ todaysVisitor }}</dd>
             </div>
             <div class="flex flex-col rounded-lg bg-rose-50 px-4 py-8 text-center">
                 <dt class="order-last text-lg font-medium text-gray-500">{{ translations.dashboard.posts }}</dt>
-                <dd class="text-4xl font-extrabold text-rose-500/75 md:text-4xl">{{ totalPosts }}</dd>
+                <dd id="totalPosts" class="text-4xl font-extrabold text-rose-500/75 md:text-4xl">{{ totalPosts }}</dd>
             </div>
             <div class="flex flex-col rounded-lg bg-rose-50 px-4 py-8 text-center">
                 <dt class="order-last text-lg font-medium text-gray-500">{{ translations.dashboard.comments }}</dt>
-                <dd class="text-4xl font-extrabold text-rose-500/75 md:text-4xl">{{ totalComments }}</dd>
+                <dd id="totalComments" class="text-4xl font-extrabold text-rose-500/75 md:text-4xl">{{ totalComments }}</dd>
             </div>
         </dl>
     </div>


### PR DESCRIPTION
## Summary
- fix analytics page JS to map last 48 hours correctly and expose callbacks
- remove leftover stub argument to ensure error handling works
- poll backend analytics endpoints so site and post tiles show live metrics

## Testing
- `pytest`
- `python -m py_compile app/routes/returnPostAnalyticsData.py`
- `python -m py_compile app/utils/afterRequest.py`


------
https://chatgpt.com/codex/tasks/task_e_68b234dbd20483278dcbda327dc4e4d1