### PR TITLE
Group user activity by IP in admin panel

### DIFF
--- a/app/routes/adminPanelActivity.py
+++ b/app/routes/adminPanelActivity.py
@@ -1,5 +1,6 @@
 import sqlite3
 from datetime import datetime
+from collections import OrderedDict
 
 from flask import Blueprint, render_template, request, session
 from settings import Settings
@@ -22,19 +23,28 @@ def adminPanelActivity():
                 LIMIT 100
                 """
             ).fetchall()
-        activities = [
-            {
-                "ip": r["ip"],
+
+        grouped = OrderedDict()
+        for r in rows:
+            ip = r["ip"]
+            activity = {
                 "country": r["country"],
                 "path": r["path"],
                 "method": r["method"],
                 "userName": r["userName"],
-                "time": datetime.utcfromtimestamp(r["timeStamp"]).strftime("%Y-%m-%d %H:%M:%S"),
+                "time": datetime.utcfromtimestamp(r["timeStamp"]).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
             }
-            for r in rows
-        ]
+            grouped.setdefault(ip, {"ip": ip, "activities": []})["activities"].append(
+                activity
+            )
+
+        activities_by_ip = list(grouped.values())
         return render_template(
-            "adminPanelActivity.html", activities=activities, admin_check=True
+            "adminPanelActivity.html",
+            activities_by_ip=activities_by_ip,
+            admin_check=True,
         )
     Log.error(
         f"{request.remote_addr} tried to reach activity admin panel without being admin"

--- a/app/routes/returnPostAnalyticsData.py
+++ b/app/routes/returnPostAnalyticsData.py
@@ -218,7 +218,7 @@ def return_site_stats() -> dict:
                 totalComments = cursor.fetchone()[0] or 0
                 connection.close()
 
-                return make_response(
+                response = make_response(
                     {
                         "payload": {
                             "totalVisitor": totalVisitor,
@@ -229,6 +229,8 @@ def return_site_stats() -> dict:
                     },
                     200,
                 )
+                response.headers["Cache-Control"] = "no-store"
+                return response
             except Exception:
                 return make_response({"message": "Unexpected error occured"}, 500)
         else:
@@ -268,7 +270,7 @@ def return_post_analytics_stats() -> dict:
                     for views in todaysVisitorData:
                         todaysVisitor += int(views[1])
 
-                    return make_response(
+                    response = make_response(
                         {
                             "payload": {
                                 "totalVisitor": totalVisitor,
@@ -277,6 +279,8 @@ def return_post_analytics_stats() -> dict:
                         },
                         200,
                     )
+                    response.headers["Cache-Control"] = "no-store"
+                    return response
                 except Exception:
                     return make_response({"message": "Unexpected error occured"}, 500)
             else:

--- a/app/static/js/postsAnalytics.js
+++ b/app/static/js/postsAnalytics.js
@@ -28,7 +28,7 @@ const postStatsUrl = "/api/v1/postAnalyticsStats?postID=" + postID;
 async function fetchPostStats() {
   debug('fetchPostStats');
   try {
-    const res = await fetch(postStatsUrl);
+    const res = await fetch(postStatsUrl, { cache: 'no-store' });
     const data = await res.json();
     if (res.ok) {
       const payload = data.payload || {};

--- a/app/static/js/siteAnalytics.js
+++ b/app/static/js/siteAnalytics.js
@@ -26,7 +26,7 @@
   async function fetchSiteStats() {
     debug('fetchSiteStats');
     try {
-      const res = await fetch(siteStatsUrl);
+      const res = await fetch(siteStatsUrl, { cache: 'no-store' });
       const data = await res.json();
       if (res.ok) {
         const payload = data.payload || {};

--- a/app/templates/adminPanelActivity.html
+++ b/app/templates/adminPanelActivity.html
@@ -5,31 +5,38 @@
 {% block body %}
 <div class="text-center">
     <h1 class="my-4 text-4xl font-medium select-none">User Activity</h1>
-    <div class="overflow-x-auto">
-        <table class="table-auto w-full max-w-5xl mx-auto text-left text-sm">
-            <thead>
-                <tr>
-                    <th class="px-2">Time</th>
-                    <th class="px-2">IP</th>
-                    <th class="px-2">Country</th>
-                    <th class="px-2">User</th>
-                    <th class="px-2">Method</th>
-                    <th class="px-2">Path</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for a in activities %}
-                <tr class="border-t">
-                    <td class="px-2 py-1">{{ a.time }}</td>
-                    <td class="px-2 py-1">{{ a.ip }}</td>
-                    <td class="px-2 py-1">{{ a.country }}</td>
-                    <td class="px-2 py-1">{{ a.userName or 'Anonymous' }}</td>
-                    <td class="px-2 py-1">{{ a.method }}</td>
-                    <td class="px-2 py-1">{{ a.path }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+    <div class="max-w-5xl mx-auto text-left text-sm space-y-4">
+        {% for group in activities_by_ip %}
+        <details class="border rounded">
+            <summary class="cursor-pointer px-2 py-1">
+                {{ group.ip }} ({{ group.activities|length }})
+            </summary>
+            <div class="overflow-x-auto">
+                <table class="table-auto w-full text-left text-sm">
+                    <thead>
+                        <tr>
+                            <th class="px-2">Time</th>
+                            <th class="px-2">Country</th>
+                            <th class="px-2">User</th>
+                            <th class="px-2">Method</th>
+                            <th class="px-2">Path</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for a in group.activities %}
+                        <tr class="border-t">
+                            <td class="px-2 py-1">{{ a.time }}</td>
+                            <td class="px-2 py-1">{{ a.country }}</td>
+                            <td class="px-2 py-1">{{ a.userName or 'Anonymous' }}</td>
+                            <td class="px-2 py-1">{{ a.method }}</td>
+                            <td class="px-2 py-1">{{ a.path }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </details>
+        {% endfor %}
     </div>
 </div>
 <a href="/admin" class="hidden md:block fixed bottom-0 left-1">


### PR DESCRIPTION
## Summary
- group activity records by IP and render dropdown per visitor in admin user activity page
- fetch analytics stats with no caching and send no-store headers so dashboard tiles update without a page refresh

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b23a9aac10832783fba511a10ee69e