### PR TITLE
Enable editing of existing posts

### DIFF
--- a/app/abi/PostStorage.json
+++ b/app/abi/PostStorage.json
@@ -1,726 +1,774 @@
 [
-    {
-      "inputs": [],
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "authorInfo",
-          "type": "string"
-        }
-      ],
-      "name": "AuthorInfoUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "bannerImageId",
-          "type": "string"
-        }
-      ],
-      "name": "BannerImageSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "ImageBlacklistUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
-      ],
-      "name": "ImageMagnetSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "PostBlacklistUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
-      ],
-      "name": "PostCreated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
-      ],
-      "name": "PostDeleted",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousSysop",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newSysop",
-          "type": "address"
-        }
-      ],
-      "name": "SysopTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "VideoBlacklistUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
-      ],
-      "name": "VideoMagnetSet",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "blacklistedImages",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "blacklistedVideos",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "authorInfo",
-          "type": "string"
-        },
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "magnetURI",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct PostStorage.MediaInput[]",
-          "name": "images",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "uint256",
-          "name": "bannerImageIndex",
-          "type": "uint256"
-        },
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "magnetURI",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct PostStorage.MediaInput[]",
-          "name": "videos",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "createPost",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
-      ],
-      "name": "deletePost",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        }
-      ],
-      "name": "getImage",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        }
-      ],
-      "name": "getImageMagnet",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getPost",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "address",
-              "name": "author",
-              "type": "address"
-            },
-            {
-              "internalType": "string",
-              "name": "contentHash",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "magnetURI",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "authorInfo",
-              "type": "string"
-            },
-            {
-              "internalType": "bool",
-              "name": "exists",
-              "type": "bool"
-            },
-            {
-              "internalType": "bool",
-              "name": "blacklisted",
-              "type": "bool"
-            },
-            {
-              "internalType": "string[]",
-              "name": "imageIds",
-              "type": "string[]"
-            },
-            {
-              "internalType": "string",
-              "name": "bannerImageId",
-              "type": "string"
-            },
-            {
-              "internalType": "string[]",
-              "name": "videoIds",
-              "type": "string[]"
-            }
-          ],
-          "internalType": "struct PostStorage.Post",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        }
-      ],
-      "name": "getVideo",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        }
-      ],
-      "name": "getVideoMagnet",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "imageMagnets",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "nextPostId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "posts",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "authorInfo",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "exists",
-          "type": "bool"
-        },
-        {
-          "internalType": "bool",
-          "name": "blacklisted",
-          "type": "bool"
-        },
-        {
-          "internalType": "string",
-          "name": "bannerImageId",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        }
-      ],
-      "name": "setBannerImage",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "setBlacklist",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "setImageBlacklist",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
-      ],
-      "name": "setImageMagnet",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "isBlacklisted",
-          "type": "bool"
-        }
-      ],
-      "name": "setVideoBlacklist",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "videoId",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
-      ],
-      "name": "setVideoMagnet",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "sysop",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newSysop",
-          "type": "address"
-        }
-      ],
-      "name": "transferSysop",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "authorInfo",
-          "type": "string"
-        }
-      ],
-      "name": "updateAuthorInfo",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "videoMagnets",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "authorInfo",
+        "type": "string"
+      }
+    ],
+    "name": "AuthorInfoUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "bannerImageId",
+        "type": "string"
+      }
+    ],
+    "name": "BannerImageSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "ImageBlacklistUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "ImageMagnetSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "PostBlacklistUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "contentHash",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "PostCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      }
+    ],
+    "name": "PostDeleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousSysop",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newSysop",
+        "type": "address"
+      }
+    ],
+    "name": "SysopTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "VideoBlacklistUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "VideoMagnetSet",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "blacklistedImages",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "blacklistedVideos",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "contentHash",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "authorInfo",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "magnetURI",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PostStorage.MediaInput[]",
+        "name": "images",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bannerImageIndex",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "magnetURI",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PostStorage.MediaInput[]",
+        "name": "videos",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "createPost",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      }
+    ],
+    "name": "deletePost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      }
+    ],
+    "name": "getImage",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      }
+    ],
+    "name": "getImageMagnet",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPost",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "contentHash",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "magnetURI",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "authorInfo",
+            "type": "string"
+          },
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "blacklisted",
+            "type": "bool"
+          },
+          {
+            "internalType": "string[]",
+            "name": "imageIds",
+            "type": "string[]"
+          },
+          {
+            "internalType": "string",
+            "name": "bannerImageId",
+            "type": "string"
+          },
+          {
+            "internalType": "string[]",
+            "name": "videoIds",
+            "type": "string[]"
+          }
+        ],
+        "internalType": "struct PostStorage.Post",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      }
+    ],
+    "name": "getVideo",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      }
+    ],
+    "name": "getVideoMagnet",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "imageMagnets",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextPostId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "posts",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "contentHash",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "authorInfo",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "blacklisted",
+        "type": "bool"
+      },
+      {
+        "internalType": "string",
+        "name": "bannerImageId",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      }
+    ],
+    "name": "setBannerImage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "setBlacklist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "setImageBlacklist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "imageId",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "setImageMagnet",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBlacklisted",
+        "type": "bool"
+      }
+    ],
+    "name": "setVideoBlacklist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "videoId",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "setVideoMagnet",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sysop",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newSysop",
+        "type": "address"
+      }
+    ],
+    "name": "transferSysop",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "authorInfo",
+        "type": "string"
+      }
+    ],
+    "name": "updateAuthorInfo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "videoMagnets",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "contentHash",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "PostUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "contentHash",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "magnetURI",
+        "type": "string"
+      }
+    ],
+    "name": "updatePost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/app/routes/editPost.py
+++ b/app/routes/editPost.py
@@ -185,6 +185,9 @@ def editPost(urlID):
                     content=post[3],
                     form=form,
                     categories=categories,
+                    post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
+                    post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
+                    rpc_url=Settings.BLOCKCHAIN_RPC_URL,
                 )
             else:
                 flashMessage(

--- a/app/static/js/editPost.js
+++ b/app/static/js/editPost.js
@@ -1,0 +1,47 @@
+(() => {
+    const debug = (...args) => window.debugLog('editPost.js', ...args);
+    debug('Loaded');
+
+    window.addEventListener('DOMContentLoaded', () => {
+        const form = document.querySelector('form');
+        if (!form) {
+            debug('No form found');
+            return;
+        }
+        let submitting = false;
+        form.addEventListener('submit', async (e) => {
+            if (submitting) return;
+            if (typeof window.ethereum === 'undefined' || typeof postContractAddress === 'undefined') {
+                debug('Ethereum or contract address undefined');
+                return;
+            }
+            const magnetField = form.querySelector('input[name="postBannerMagnet"]');
+            if (magnetField && !magnetField.value) {
+                debug('Waiting for banner magnet');
+                return;
+            }
+            e.preventDefault();
+            try {
+                await window.ethereum.request({ method: 'eth_requestAccounts' });
+                const title = form.postTitle.value.trim();
+                const tags = form.postTags.value.trim();
+                const abs = form.postAbstract.value.trim();
+                const content = form.postContent.value.trim();
+                const category = form.postCategory.value;
+                const payload = `${title}|${tags}|${abs}|${content}|${category}`;
+                const provider = new ethers.providers.Web3Provider(window.ethereum);
+                const signer = provider.getSigner();
+                const contract = new ethers.Contract(postContractAddress, postContractAbi, signer);
+                const postId = window.location.pathname.split('/').pop();
+                const tx = await contract.updatePost(postId, payload, '');
+                debug('Transaction sent', tx.hash);
+                await tx.wait();
+                debug('Transaction mined');
+                submitting = true;
+                form.submit();
+            } catch (err) {
+                debug('Failed to update post on-chain', err);
+            }
+        });
+    });
+})();

--- a/app/templates/editPost.html
+++ b/app/templates/editPost.html
@@ -62,5 +62,7 @@
     </form>
     <script src="{{ url_for('static', filename='js/markdownEditor.js') }}"></script>
     <script src="{{ url_for('static', filename='js/bannerMagnet.js') }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <script src="{{ url_for('static', filename='js/editPost.js') }}"></script>
 </div>
 {% endblock body %}

--- a/contracts/PostStorage.sol
+++ b/contracts/PostStorage.sol
@@ -38,6 +38,11 @@ contract PostStorage {
         string magnetURI
     );
     event PostDeleted(uint256 indexed postId);
+    event PostUpdated(
+        uint256 indexed postId,
+        string contentHash,
+        string magnetURI
+    );
     event PostBlacklistUpdated(uint256 indexed postId, bool isBlacklisted);
     event ImageMagnetSet(string indexed imageId, string magnetURI);
     event ImageBlacklistUpdated(string indexed imageId, bool isBlacklisted);
@@ -141,6 +146,19 @@ contract PostStorage {
         }
         delete posts[postId];
         emit PostDeleted(postId);
+    }
+
+    function updatePost(
+        uint256 postId,
+        string calldata contentHash,
+        string calldata magnetURI
+    ) external {
+        Post storage p = posts[postId];
+        require(p.exists, "no post");
+        require(msg.sender == p.author || msg.sender == sysop, "not authorized");
+        p.contentHash = contentHash;
+        p.magnetURI = magnetURI;
+        emit PostUpdated(postId, contentHash, magnetURI);
     }
 
     function setBlacklist(uint256 postId, bool isBlacklisted) external onlySysop {


### PR DESCRIPTION
## Summary
- allow updating posts on-chain with new `updatePost` function
- wire edit page to call smart contract and expose blockchain config
- add front-end script to submit edits through the contract

## Testing
- `npx solc@0.8.20 --bin contracts/PostStorage.sol >/tmp/post.bin && echo "compiled"`
- `cd app && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b25db7211483278fe282878b84511b