### PR TITLE
feat: add forum contract and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Simple Flask app container
+FROM python:3.10-slim
+WORKDIR /app
+COPY app /app
+# Install dependencies using uv if available
+RUN pip install --no-cache-dir uv || true \
+    && (cd /app && uv pip install --system .) || true
+EXPOSE 1283
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Sponsored by [CreateMyBanner](https://createmybanner.com)
 - **Member Tiers** – Metered paywall with on-chain accounting
 - **Sponsor Blocks** – First‑party ad slots with frequency capping
 - **Tip Jar** – Per‑author and per‑post tipping using Ethereum with a configurable sysop commission
+- **Forum Boards** – Minimal 4chan-inspired smart contract storing latest post images
 - **Torrent-backed Media** – Images are also distributed via BitTorrent for load balancing
 
 ## 🚀 Quick Start
@@ -42,6 +43,16 @@ uv run app.py
 ```
 
 Visit `http://localhost:1283` in your browser.
+
+### Docker Compose
+
+Run the app and a local Ethereum test chain with separate containers:
+
+```bash
+docker-compose up --build
+```
+
+The Flask service listens on `1283` while Ganache exposes `8545`.
 
 ### Blockchain
 

--- a/app/abi/Forum.json
+++ b/app/abi/Forum.json
@@ -1,0 +1,39 @@
+{
+  "abi": [
+    {
+      "inputs": [{"internalType": "string", "name": "name", "type": "string"}],
+      "name": "createBoard",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "boardId", "type": "uint256"},
+        {"internalType": "string", "name": "content", "type": "string"},
+        {"internalType": "string", "name": "image", "type": "string"}
+      ],
+      "name": "createPost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getBoards",
+      "outputs": [
+        {
+          "components": [
+            {"internalType": "string", "name": "name", "type": "string"},
+            {"internalType": "string", "name": "latestImage", "type": "string"}
+          ],
+          "internalType": "struct Forum.Board[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/app/app.py
+++ b/app/app.py
@@ -71,6 +71,7 @@ from routes.passwordReset import (
     passwordResetBlueprint,
 )
 from routes.post import postBlueprint
+from routes.board import boardBlueprint
 from routes.postStats import postStatsBlueprint
 from routes.postsAnalytics import (
     analyticsBlueprint,
@@ -300,6 +301,7 @@ app.register_blueprint(analyticsBlueprint)
 app.register_blueprint(returnPostAnalyticsDataBlueprint)
 app.register_blueprint(postStatsBlueprint)
 app.register_blueprint(adminPanelActivityBlueprint)
+app.register_blueprint(boardBlueprint)
 app.register_blueprint(commentsBlueprint)
 
 

--- a/app/routes/board.py
+++ b/app/routes/board.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, render_template
+
+boardBlueprint = Blueprint('board', __name__)
+
+@boardBlueprint.route('/board/<int:board_id>')
+def board(board_id):
+    return render_template('board.html', board_id=board_id)

--- a/app/static/js/forum.js
+++ b/app/static/js/forum.js
@@ -1,0 +1,26 @@
+// Front page forum tiles loader
+// Requires ethers.js and a deployed Forum contract
+
+async function loadForumTiles() {
+    const container = document.getElementById('board-tiles');
+    if (!container || !window.ethereum) return;
+
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    const abiResponse = await fetch('/abi/Forum.json');
+    const abiJson = await abiResponse.json();
+    const forumAddress = window.FORUM_ADDRESS || '0x0000000000000000000000000000000000000000';
+    const forum = new ethers.Contract(forumAddress, abiJson.abi, provider);
+
+    const boards = await forum.getBoards();
+    boards.forEach((b, idx) => {
+        const tile = document.createElement('div');
+        tile.className = 'post-tile';
+        tile.innerHTML = `<img src="${b.latestImage}" alt="${b.name}" class="w-full h-32 object-cover"/><p class="mt-1 text-center">${b.name}</p>`;
+        tile.addEventListener('click', () => {
+            window.location.href = `/board/${idx}`;
+        });
+        container.appendChild(tile);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadForumTiles);

--- a/app/templates/board.html
+++ b/app/templates/board.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block head %}
+<title>Board</title>
+{% endblock head %}
+{% block body %}
+<div class="mx-auto w-10/12 mt-6">
+    <h1 class="text-xl font-semibold mb-4">Board</h1>
+    <div id="board-posts" class="space-y-4"></div>
+</div>
+{% endblock body %}
+{% block scripts %}
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+  <script src="{{ url_for('static', filename='js/forum.js') }}"></script>
+{% endblock scripts %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -51,6 +51,8 @@
     </a>
 </div>
 
+<div id="board-tiles" class="post-tiles-grid mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-6"></div>
+
 <div
     class="flex justify-between mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-8"
 >
@@ -80,6 +82,8 @@
 {% endblock body %}
 
 {% block scripts %}
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+  <script src="{{ url_for('static', filename='js/forum.js') }}"></script>
   <script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
   <script src="{{ url_for('static', filename='js/loadPosts.js') }}"></script>
   <script src="{{ url_for('static', filename='js/postStats.js') }}"></script>

--- a/contracts/Forum.sol
+++ b/contracts/Forum.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Simple forum board inspired by 4chan
+/// @notice Stores boards and latest post image on-chain. Posts themselves are
+///         emitted as events to avoid heavy storage. Only the contract owner can
+///         create boards or blacklist posts.
+contract Forum {
+    struct Board {
+        string name;
+        string latestImage;
+    }
+
+    struct Post {
+        uint256 boardId;
+        uint256 id;
+        string content;
+        string image;
+    }
+
+    Board[] public boards;
+    mapping(uint256 => bool) public blacklisted;
+    uint256 public postCount;
+    address public owner;
+
+    event BoardCreated(uint256 indexed boardId, string name);
+    event PostCreated(
+        uint256 indexed boardId,
+        uint256 indexed postId,
+        string content,
+        string image
+    );
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function createBoard(string calldata name) external onlyOwner {
+        boards.push(Board({name: name, latestImage: ""}));
+        emit BoardCreated(boards.length - 1, name);
+    }
+
+    function createPost(
+        uint256 boardId,
+        string calldata content,
+        string calldata image
+    ) external {
+        require(boardId < boards.length, "invalid board");
+        postCount++;
+        boards[boardId].latestImage = image;
+        emit PostCreated(boardId, postCount, content, image);
+    }
+
+    function blacklist(uint256 postId) external onlyOwner {
+        blacklisted[postId] = true;
+    }
+
+    function getBoards() external view returns (Board[] memory) {
+        return boards;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "1283:1283"
+    volumes:
+      - ./app:/app
+    depends_on:
+      - blockchain
+  blockchain:
+    image: trufflesuite/ganache-cli
+    ports:
+      - "8545:8545"


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose for modular services
- introduce simple Forum smart contract and ABI
- wire up front page board tiles and board route

## Testing
- `python -m py_compile app/routes/board.py app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49c49a2748327926b8cd776574a2d