### PR TITLE
Remove local blockchain node from Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Visit `http://localhost:1283` in your browser.
 
 ### Docker Compose
 
-Run the app and a local Ethereum test chain with separate containers:
+Run the app with Docker:
 
 ```bash
 docker-compose up --build
 ```
 
-The Flask service listens on `1283` while Ganache exposes `8545`.
+The Flask service listens on `1283`.
 
 ### Blockchain
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,3 @@ services:
       - "1283:1283"
     volumes:
       - ./app:/app
-    depends_on:
-      - blockchain
-  blockchain:
-    image: trufflesuite/ganache-cli
-    ports:
-      - "8545:8545"


### PR DESCRIPTION
## Summary
- remove Ganache blockchain service from Docker Compose
- update README Docker instructions to run only the Flask app

## Testing
- `/usr/bin/python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49f0b00b08327be5c71d8a91599ed