### PR TITLE
Fix Dockerfile to install Flask dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY app /app
-# Install dependencies using uv if available
-RUN pip install --no-cache-dir uv || true \
-    && (cd /app && uv pip install --system .) || true
+# Install dependencies using uv if available, fall back to pip
+RUN (pip install --no-cache-dir uv && uv pip install --system .) || \
+    pip install --no-cache-dir .
 EXPOSE 1283
 CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- ensure container installs project dependencies using uv or pip fallback

## Testing
- `docker compose run --build --rm web python -c "import flask, sys; print(flask.__version__)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a07e529083279948655e33ba0635