### PR TITLE
Install dependencies from requirements file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY app /app
 # Install dependencies using uv if available, fall back to pip
-RUN (pip install --no-cache-dir uv && uv pip install --system .) || \
-    pip install --no-cache-dir .
+RUN (pip install --no-cache-dir uv && uv pip install --system -r requirements.txt) || \
+    pip install --no-cache-dir -r requirements.txt
 EXPOSE 1283
 CMD ["python", "app.py"]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,16 @@
+flask-wtf>=1.2.2
+flask>=3.1.0
+geoip2>=5.0.1
+passlib>=1.7.4
+tamga>=1.4.0
+user-agents>=2.2.0
+wtforms>=3.2.1
+markdown2
+bleach
+html2text
+networkx
+nltk
+scikit-learn
+gTTS
+web3
+libtorrent


### PR DESCRIPTION
## Summary
- use requirements file for dependency installation in Docker image
- add `app/requirements.txt` listing project dependencies

## Testing
- `python -m py_compile app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a1422afc8327af208cb67aaf526d