### PR TITLE
Add forum board tiles to index page

### DIFF
--- a/app/static/css/forumTiles.css
+++ b/app/static/css/forumTiles.css
@@ -1,0 +1,43 @@
+/* Forum board tiles styling */
+
+.forum-tiles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+}
+
+.forum-tile {
+    position: relative;
+    padding-top: 100%; /* square */
+    background-size: cover;
+    background-position: center;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    transition: transform 0.15s ease, box-shadow 0.3s ease;
+}
+
+.forum-tile:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.forum-tile-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+    padding: 0.5rem;
+}
+
+.forum-tile-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    background-color: rgba(255, 255, 255, 0.85);
+    color: #000;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+}

--- a/app/static/js/forum.js
+++ b/app/static/js/forum.js
@@ -14,8 +14,9 @@ async function loadForumTiles() {
     const boards = await forum.getBoards();
     boards.forEach((b, idx) => {
         const tile = document.createElement('div');
-        tile.className = 'post-tile';
-        tile.innerHTML = `<img src="${b.latestImage}" alt="${b.name}" class="w-full h-32 object-cover"/><p class="mt-1 text-center">${b.name}</p>`;
+        tile.className = 'forum-tile';
+        tile.style.backgroundImage = `url(${b.latestImage})`;
+        tile.innerHTML = `<div class="forum-tile-overlay"><span class="forum-tile-title">${b.name}</span></div>`;
         tile.addEventListener('click', () => {
             window.location.href = `/board/${idx}`;
         });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,6 +23,7 @@
     name="twitter:image"
     content="https://raw.githubusercontent.com/DogukanUrker/flaskBlog/main/images/Icon180.ico"
 />
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forumTiles.css') }}" />
 <link rel="stylesheet" href="{{ url_for('static', filename='css/postTiles.css') }}" />
 {% endblock head %} {% block body %}
 
@@ -51,7 +52,7 @@
     </a>
 </div>
 
-<div id="board-tiles" class="post-tiles-grid mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-6"></div>
+<div id="board-tiles" class="forum-tiles-grid mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-6"></div>
 
 <div
     class="flex justify-between mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-8"


### PR DESCRIPTION
## Summary
- style new forum board tiles block
- load board data into new tiles
- include board tiles above existing posts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a84e266c8327828d148d08914b3f