### PR TITLE
Add forum route and blockchain post/comment contracts

### DIFF
--- a/app/abi/Board.json
+++ b/app/abi/Board.json
@@ -1,0 +1,44 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {"internalType": "string", "name": "name", "type": "string"}
+      ],
+      "name": "createBoard",
+      "outputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "name": "getBoard",
+      "outputs": [
+        {"internalType": "string", "name": "name", "type": "string"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "boardCount",
+      "outputs": [
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {"indexed": true, "internalType": "uint256", "name": "id", "type": "uint256"},
+        {"indexed": false, "internalType": "string", "name": "name", "type": "string"}
+      ],
+      "name": "BoardCreated",
+      "type": "event"
+    }
+  ]
+}

--- a/app/abi/Comments.json
+++ b/app/abi/Comments.json
@@ -1,0 +1,69 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {"internalType": "address", "name": "postsAddress", "type": "address"}
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {"indexed": true, "internalType": "uint256", "name": "id", "type": "uint256"},
+        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
+        {"indexed": false, "internalType": "string", "name": "username", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "email", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "body", "type": "string"}
+      ],
+      "name": "CommentAdded",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"internalType": "string", "name": "username", "type": "string"},
+        {"internalType": "string", "name": "email", "type": "string"},
+        {"internalType": "string", "name": "body", "type": "string"}
+      ],
+      "name": "addComment",
+      "outputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "name": "getComment",
+      "outputs": [
+        {
+          "components": [
+            {"internalType": "address", "name": "author", "type": "address"},
+            {"internalType": "string", "name": "username", "type": "string"},
+            {"internalType": "string", "name": "email", "type": "string"},
+            {"internalType": "string", "name": "body", "type": "string"},
+            {"internalType": "uint256", "name": "postId", "type": "uint256"}
+          ],
+          "internalType": "struct Comments.Comment",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "commentCount",
+      "outputs": [
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/app/abi/Posts.json
+++ b/app/abi/Posts.json
@@ -1,0 +1,72 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {"internalType": "address", "name": "boardAddress", "type": "address"}
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {"indexed": true, "internalType": "uint256", "name": "id", "type": "uint256"},
+        {"indexed": true, "internalType": "uint256", "name": "boardId", "type": "uint256"},
+        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
+        {"indexed": false, "internalType": "string", "name": "username", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "email", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "subject", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "body", "type": "string"}
+      ],
+      "name": "PostCreated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "boardId", "type": "uint256"},
+        {"internalType": "string", "name": "username", "type": "string"},
+        {"internalType": "string", "name": "email", "type": "string"},
+        {"internalType": "string", "name": "subject", "type": "string"},
+        {"internalType": "string", "name": "body", "type": "string"}
+      ],
+      "name": "createPost",
+      "outputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"}
+      ],
+      "name": "getPost",
+      "outputs": [
+        {
+          "components": [
+            {"internalType": "address", "name": "author", "type": "address"},
+            {"internalType": "string", "name": "username", "type": "string"},
+            {"internalType": "string", "name": "email", "type": "string"},
+            {"internalType": "string", "name": "subject", "type": "string"},
+            {"internalType": "string", "name": "body", "type": "string"},
+            {"internalType": "uint256", "name": "boardId", "type": "uint256"}
+          ],
+          "internalType": "struct Posts.Post",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "postCount",
+      "outputs": [
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/app/app.py
+++ b/app/app.py
@@ -72,6 +72,7 @@ from routes.passwordReset import (
 )
 from routes.post import postBlueprint
 from routes.board import boardBlueprint
+from routes.forum import forumBlueprint
 from routes.postStats import postStatsBlueprint
 from routes.postsAnalytics import (
     analyticsBlueprint,
@@ -303,6 +304,7 @@ app.register_blueprint(returnPostAnalyticsDataBlueprint)
 app.register_blueprint(postStatsBlueprint)
 app.register_blueprint(adminPanelActivityBlueprint)
 app.register_blueprint(boardBlueprint)
+app.register_blueprint(forumBlueprint)
 app.register_blueprint(commentsBlueprint)
 app.register_blueprint(apiBlueprint)
 

--- a/app/routes/comments.py
+++ b/app/routes/comments.py
@@ -9,15 +9,17 @@ commentsBlueprint = Blueprint("comments", __name__)
 def add_comment():
     data = request.get_json(silent=True) or {}
     post_id = data.get("postID")
+    username = data.get("username") or "Anonymous"
+    email = data.get("email") or ""
     content = data.get("content")
     if post_id is None or not content:
         return jsonify({"error": "postID and content are required"}), 400
 
-    contract_info = Settings.BLOCKCHAIN_CONTRACTS["CommentStorage"]
+    contract_info = Settings.BLOCKCHAIN_CONTRACTS["Comments"]
     w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
     contract = w3.eth.contract(address=contract_info["address"], abi=contract_info["abi"])
     try:
-        tx_hash = contract.functions.addComment(post_id, content).transact()
+        tx_hash = contract.functions.addComment(post_id, username, email, content).transact()
         return jsonify({"txHash": tx_hash.hex()}), 200
     except Exception as exc:  # pragma: no cover - external call
         return jsonify({"error": str(exc)}), 500

--- a/app/routes/forum.py
+++ b/app/routes/forum.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+forumBlueprint = Blueprint("forum", __name__)
+
+
+@forumBlueprint.route("/forum")
+def forum():
+    """Render the forum board index."""
+    return render_template("forum.html")

--- a/app/settings.py
+++ b/app/settings.py
@@ -158,6 +158,18 @@ class Settings:
     # Addresses and ABIs for individual smart contracts managed by the sysop
     ABI_PATH = Path(__file__).resolve().parent / "abi"
     BLOCKCHAIN_CONTRACTS = {
+        "Board": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "abi": json.loads((ABI_PATH / "Board.json").read_text()),
+        },
+        "Posts": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "abi": json.loads((ABI_PATH / "Posts.json").read_text()),
+        },
+        "Comments": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "abi": json.loads((ABI_PATH / "Comments.json").read_text()),
+        },
         "PostStorage": {
             "address": "0x73625B5ef40e8254E65179aBdD393733f6901A18",
             "abi": json.loads((ABI_PATH / "PostStorage.json").read_text()),

--- a/app/static/js/comments.js
+++ b/app/static/js/comments.js
@@ -114,24 +114,24 @@
 
     async function loadExistingComments() {
       debug('Loading existing comments');
-      let nextId;
+      let total;
       try {
-        nextId = await contract.nextCommentId();
+        total = await contract.commentCount();
       } catch (err) {
-        debug('nextCommentId failed', err);
+        debug('commentCount failed', err);
         commentsEl.textContent = 'Failed to load comments.';
         return;
       }
-      const total = nextId.toNumber ? nextId.toNumber() : parseInt(nextId);
-      for (let i = 0; i < total; i++) {
+      const count = total.toNumber ? total.toNumber() : parseInt(total);
+      for (let i = 0; i < count; i++) {
         if (loadedComments.has(i)) continue;
         try {
           const c = await contract.getComment(i);
-        if (!c.exists || c.postId.toString() !== postUrlID.toString() || c.blacklisted || localBlacklist.has(i) || (userBL.authors || []).includes(c.author.toLowerCase())) continue;
-        renderComment(i, c.author, c.content);
-      } catch (err) {
-        debug('getComment failed', i, err);
-      }
+          if (c.postId.toString() !== postUrlID.toString() || localBlacklist.has(i) || (userBL.authors || []).includes(c.author.toLowerCase())) continue;
+          renderComment(i, c.username, c.body);
+        } catch (err) {
+          debug('getComment failed', i, err);
+        }
       }
       if (loadedComments.size === 0) {
         commentsEl.innerHTML = '<p>No comments yet.</p>';
@@ -156,7 +156,7 @@
           window.commentContractAbi,
           signer
         );
-        const tx = await c.addComment(postUrlID, content);
+        const tx = await c.addComment(postUrlID, '', '', content);
         await tx.wait();
         textarea.value = '';
       } catch (err) {

--- a/app/templates/forum.html
+++ b/app/templates/forum.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block head %}
+<title>Forum</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forumTiles.css') }}" />
+{% endblock head %}
+{% block body %}
+<div id="board-tiles" class="forum-tiles-grid mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-6"></div>
+{% endblock body %}
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+<script src="{{ url_for('static', filename='js/forum.js') }}"></script>
+{% endblock scripts %}

--- a/app/utils/contextProcessor/blockchain.py
+++ b/app/utils/contextProcessor/blockchain.py
@@ -7,7 +7,7 @@ def inject_blockchain():
     if "walletAddress" not in session:
         return {}
     post_contract = Settings.BLOCKCHAIN_CONTRACTS.get("PostStorage", {})
-    comment_contract = Settings.BLOCKCHAIN_CONTRACTS.get("CommentStorage", {})
+    comment_contract = Settings.BLOCKCHAIN_CONTRACTS.get("Comments", {})
     tip_jar_contract = Settings.BLOCKCHAIN_CONTRACTS.get("TipJar", {})
     return {
         "rpc_url": Settings.BLOCKCHAIN_RPC_URL,

--- a/contracts/Board.sol
+++ b/contracts/Board.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Board registry for forum boards
+/// @notice Stores board names and exposes their identifiers
+contract Board {
+    struct BoardInfo {
+        string name;
+    }
+
+    mapping(uint256 => BoardInfo) public boards;
+    uint256 public boardCount;
+
+    event BoardCreated(uint256 indexed id, string name);
+
+    /// @notice Create a new board
+    /// @param name Name of the board
+    /// @return id Identifier of the created board
+    function createBoard(string calldata name) external returns (uint256 id) {
+        id = boardCount++;
+        boards[id] = BoardInfo(name);
+        emit BoardCreated(id, name);
+    }
+
+    /// @notice Retrieve board information
+    /// @param id Identifier of the board
+    /// @return name Name of the board
+    function getBoard(uint256 id) external view returns (string memory name) {
+        BoardInfo storage b = boards[id];
+        name = b.name;
+    }
+}

--- a/contracts/Comments.sol
+++ b/contracts/Comments.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Comments contract storing replies to posts
+interface IPosts {
+    function postCount() external view returns (uint256);
+}
+
+contract Comments {
+    struct Comment {
+        address author;
+        string username;
+        string email;
+        string body;
+        uint256 postId;
+    }
+
+    IPosts public postsContract;
+    uint256 public commentCount;
+    mapping(uint256 => Comment) public comments;
+
+    event CommentAdded(
+        uint256 indexed id,
+        uint256 indexed postId,
+        address indexed author,
+        string username,
+        string email,
+        string body
+    );
+
+    constructor(address postsAddress) {
+        postsContract = IPosts(postsAddress);
+    }
+
+    /// @notice Add a comment to a post
+    /// @param postId The post identifier
+    /// @param username Display name, defaults to "Anonymous" if empty
+    /// @param email Optional contact email
+    /// @param body Comment body text
+    /// @return id Identifier of the created comment
+    function addComment(
+        uint256 postId,
+        string calldata username,
+        string calldata email,
+        string calldata body
+    ) external returns (uint256 id) {
+        require(postId < postsContract.postCount(), "invalid post");
+        string memory name = bytes(username).length > 0 ? username : "Anonymous";
+        id = commentCount++;
+        comments[id] = Comment(msg.sender, name, email, body, postId);
+        emit CommentAdded(id, postId, msg.sender, name, email, body);
+    }
+
+    /// @notice Retrieve a comment
+    /// @param id Identifier of the comment
+    /// @return c The comment data
+    function getComment(uint256 id) external view returns (Comment memory c) {
+        c = comments[id];
+    }
+}

--- a/contracts/Posts.sol
+++ b/contracts/Posts.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Posts contract linking forum posts to boards
+interface IBoard {
+    function boardCount() external view returns (uint256);
+}
+
+contract Posts {
+    struct Post {
+        address author;
+        string username;
+        string email;
+        string subject;
+        string body;
+        uint256 boardId;
+    }
+
+    IBoard public boardContract;
+    uint256 public postCount;
+    mapping(uint256 => Post) public posts;
+
+    event PostCreated(
+        uint256 indexed id,
+        uint256 indexed boardId,
+        address indexed author,
+        string username,
+        string email,
+        string subject,
+        string body
+    );
+
+    constructor(address boardAddress) {
+        boardContract = IBoard(boardAddress);
+    }
+
+    /// @notice Create a new post under a board
+    /// @param boardId The board identifier
+    /// @param username Chosen display name, defaults to "Anonymous" if empty
+    /// @param email Optional contact email
+    /// @param subject Post subject line
+    /// @param body Post body content
+    /// @return id Identifier of the created post
+    function createPost(
+        uint256 boardId,
+        string calldata username,
+        string calldata email,
+        string calldata subject,
+        string calldata body
+    ) external returns (uint256 id) {
+        require(boardId < boardContract.boardCount(), "invalid board");
+        string memory name = bytes(username).length > 0 ? username : "Anonymous";
+        id = postCount++;
+        posts[id] = Post(msg.sender, name, email, subject, body, boardId);
+        emit PostCreated(id, boardId, msg.sender, name, email, subject, body);
+    }
+
+    /// @notice Retrieve a post
+    /// @param id Identifier of the post
+    /// @return p The post data
+    function getPost(uint256 id) external view returns (Post memory p) {
+        p = posts[id];
+    }
+}


### PR DESCRIPTION
## Summary
- add `/forum` route and template for board index
- create Board, Posts, and Comments solidity contracts with default "Anonymous" names
- wire comments to new contract and update client script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ad9476648327bfeb3b0a46f12f2b