### PR TITLE
refactor: route posts under board and add filters

### DIFF
--- a/app/routes/board.py
+++ b/app/routes/board.py
@@ -1,7 +1,15 @@
 from flask import Blueprint, render_template
+from settings import Settings
 
-boardBlueprint = Blueprint('board', __name__)
+boardBlueprint = Blueprint("board", __name__)
 
-@boardBlueprint.route('/board/<int:board_id>')
-def board(board_id):
-    return render_template('board.html', board_id=board_id)
+
+@boardBlueprint.route("/board")
+def board():
+    return render_template(
+        "board.html",
+        post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
+        post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+        word_filters=Settings.BOARD_WORD_FILTERS,
+    )

--- a/app/settings.py
+++ b/app/settings.py
@@ -187,3 +187,8 @@ class Settings:
             "abi": json.loads((ABI_PATH / "TipJar.json").read_text()),
         },
     }
+
+    # Words on the board that should be filtered in posts and comments
+    BOARD_WORD_FILTERS = {
+        "badword": "[censored]",
+    }

--- a/app/static/js/forum.js
+++ b/app/static/js/forum.js
@@ -18,7 +18,7 @@ async function loadForumTiles() {
         tile.style.backgroundImage = `url(${b.latestImage})`;
         tile.innerHTML = `<div class="forum-tile-overlay"><span class="forum-tile-title">${b.name}</span></div>`;
         tile.addEventListener('click', () => {
-            window.location.href = `/board/${idx}`;
+            window.location.href = `/board`;
         });
         container.appendChild(tile);
     });

--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -2,6 +2,15 @@
     const debug = (...args) => window.debugLog('loadPosts.js', ...args);
     debug('Loaded');
 
+    function applyFilters(text) {
+        const filters = window.boardWordFilters || {};
+        for (const [bad, good] of Object.entries(filters)) {
+            const regex = new RegExp(bad, 'gi');
+            text = text.replace(regex, good);
+        }
+        return text;
+    }
+
     (async () => {
     debug('Loading posts');
     if (typeof ethers === 'undefined') {
@@ -38,10 +47,10 @@
                 continue;
             }
             const parts = p.contentHash.split('|');
-            const title = parts[0] || '';
+            const title = applyFilters(parts[0] || '');
             const category = parts[4] || '';
             const link = document.createElement('a');
-            link.href = `/post/${id}`;
+            link.href = `/board/${id}`;
             link.className = 'post-tile';
             link.dataset.postId = id;
             link.dataset.w = Math.floor(Math.random() * 3) + 1;

--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -9,7 +9,7 @@ let currentTreeSignature = "";
 async function fetchCommentTree() {
   debug('fetchCommentTree');
   try {
-    const response = await fetch(`/post/${postUrlID}/comment-tree`);
+    const response = await fetch(`/board/${postUrlID}/comment-tree`);
     const data = await response.json();
     debug('comment tree data', data);
     const signature = data.nodes.map((n) => n.id).sort().join(",");

--- a/app/templates/board.html
+++ b/app/templates/board.html
@@ -1,14 +1,18 @@
 {% extends 'layout.html' %}
 {% block head %}
 <title>Board</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/postTiles.css') }}" />
 {% endblock head %}
 {% block body %}
-<div class="mx-auto w-10/12 mt-6">
-    <h1 class="text-xl font-semibold mb-4">Board</h1>
-    <div id="board-posts" class="space-y-4"></div>
-</div>
+<div id="posts-container" class="post-tiles-grid mx-auto w-11/12 md:w-11/12 lg:w-10/12 2xl:w-9/12 mt-6"></div>
 {% endblock body %}
 {% block scripts %}
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
-  <script src="{{ url_for('static', filename='js/forum.js') }}"></script>
+  <script>
+    window.postContractAddress = "{{ post_contract_address }}";
+    window.postContractAbi = {{ post_contract_abi | tojson }};
+    window.rpcUrl = "{{ rpc_url }}";
+    window.boardWordFilters = {{ word_filters | tojson }};
+  </script>
+  <script src="{{ url_for('static', filename='js/loadPosts.js') }}"></script>
 {% endblock scripts %}

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -29,6 +29,7 @@
     <h1 class="text-2xl md:text-3xl mt-3 text-rose-500 w-full text-center font-bold">{{ title }}</h1>
     <div class="flex items-center justify-center gap-2 my-4 select-none opacity-75">
         <p class="text-sm font-medium"><span id="reading-time">{{ reading_time }}</span> {{ translations.post.minRead }}</p>
+        {% if timeStamp %}<p class="text-sm">{{ timeStamp }}</p>{% endif %}
     </div>
     <div class="text-center font-sm max-w-full">{{ abstract }}</div>
     <div class="divider"></div>
@@ -79,6 +80,7 @@
     const postUrlID = {{ id }};
     window.postAuthor = "{{ author }}";
     window.blacklistedComments = {{ blacklisted_comments | tojson }};
+    window.boardWordFilters = {{ word_filters | tojson }};
     document.getElementById('blacklist-author')?.addEventListener('click', () => {
         if (window.Blacklist) {
             window.Blacklist.addAuthor('{{ author }}');


### PR DESCRIPTION
## Summary
- serve board at `/board` with contract info and word filters
- expose posts under `/board/<id>` and filter content with blockchain timestamps
- sanitize comments with board word filters, simple timestamping and anchors

## Testing
- `python -m py_compile app/settings.py app/routes/board.py app/routes/post.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4af719de48327ac7e6a5c7f985cd2