### PR TITLE
Require dependency addresses at deployment

### DIFF
--- a/contracts/Comments.sol
+++ b/contracts/Comments.sol
@@ -36,6 +36,7 @@ contract Comments {
     }
 
     constructor(address postsAddress) {
+        require(postsAddress != address(0), "invalid posts address");
         sysop = msg.sender;
         postsContract = IPosts(postsAddress);
     }
@@ -44,10 +45,6 @@ contract Comments {
         require(newSysop != address(0), "bad sysop");
         emit SysopTransferred(sysop, newSysop);
         sysop = newSysop;
-    }
-
-    function setPostsContract(address postsAddress) external onlySysop {
-        postsContract = IPosts(postsAddress);
     }
 
     /// @notice Add a comment to a post

--- a/contracts/Posts.sol
+++ b/contracts/Posts.sol
@@ -38,6 +38,7 @@ contract Posts {
     }
 
     constructor(address boardAddress) {
+        require(boardAddress != address(0), "invalid board address");
         sysop = msg.sender;
         boardContract = IBoard(boardAddress);
     }
@@ -46,10 +47,6 @@ contract Posts {
         require(newSysop != address(0), "bad sysop");
         emit SysopTransferred(sysop, newSysop);
         sysop = newSysop;
-    }
-
-    function setBoardContract(address boardAddress) external onlySysop {
-        boardContract = IBoard(boardAddress);
     }
 
     /// @notice Create a new post under a board


### PR DESCRIPTION
## Summary
- Require valid Posts contract address when deploying Comments
- Require valid Board contract address when deploying Posts
- Remove post-deployment setters for dependency addresses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ba0799588327a0f17fd8afbb4430