### PR TITLE
Refactor Board contract to manage posts and moderators

### DIFF
--- a/contracts/Board.sol
+++ b/contracts/Board.sol
@@ -2,37 +2,46 @@
 pragma solidity ^0.8.20;
 
 /// @title Board registry for forum boards
-/// @notice Stores board metadata and exposes their identifiers
+/// @notice Stores board metadata, moderators and their posts
 contract Board {
+    struct Post {
+        uint256 id;
+    }
+
     struct BoardInfo {
-        string subject;
-        string body;
-        string email;
         string name;
+        string banner;
+        Post[] posts;
+        address[] moderators;
     }
 
     address public sysop;
-    mapping(uint256 => BoardInfo) public boards;
+    mapping(uint256 => BoardInfo) private boards;
     uint256 public boardCount;
 
-    event BoardCreated(
-        uint256 indexed id,
-        string subject,
-        string body,
-        string email,
-        string name
-    );
-    event BoardUpdated(
-        uint256 indexed id,
-        string subject,
-        string body,
-        string email,
-        string name
-    );
+    event BoardCreated(uint256 indexed id, string name, string banner);
+    event BoardUpdated(uint256 indexed id, string name, string banner);
+    event PostAdded(uint256 indexed boardId, uint256 indexed postId);
+    event ModeratorsUpdated(uint256 indexed boardId, address[] moderators);
     event SysopTransferred(address indexed previousSysop, address indexed newSysop);
 
     modifier onlySysop() {
         require(msg.sender == sysop, "only sysop");
+        _;
+    }
+
+    modifier onlySysopOrModerator(uint256 boardId) {
+        if (msg.sender != sysop) {
+            bool ok = false;
+            address[] storage mods = boards[boardId].moderators;
+            for (uint256 i = 0; i < mods.length; i++) {
+                if (mods[i] == msg.sender) {
+                    ok = true;
+                    break;
+                }
+            }
+            require(ok, "not moderator");
+        }
         _;
     }
 
@@ -46,47 +55,69 @@ contract Board {
         sysop = newSysop;
     }
 
-    /// @notice Create a new board entry
-    /// @param subject Subject of the board entry
-    /// @param body Body content
-    /// @param email Optional contact email
-    /// @param name Display name, defaults to "Anonymous" if empty
-    /// @return id Identifier of the created board entry
+    /// @notice Create a new board
+    /// @param name Name of the board
+    /// @param banner Banner image or identifier
+    /// @param moderators Initial list of moderators
+    /// @return id Identifier of the created board
     function createBoard(
-        string calldata subject,
-        string calldata body,
-        string calldata email,
-        string calldata name
+        string calldata name,
+        string calldata banner,
+        address[] calldata moderators
     ) external onlySysop returns (uint256 id) {
         id = boardCount++;
-        string memory finalName = bytes(name).length > 0 ? name : "Anonymous";
-        boards[id] = BoardInfo(subject, body, email, finalName);
-        emit BoardCreated(id, subject, body, email, finalName);
+        BoardInfo storage b = boards[id];
+        b.name = name;
+        b.banner = banner;
+        for (uint256 i = 0; i < moderators.length; i++) {
+            b.moderators.push(moderators[i]);
+        }
+        emit BoardCreated(id, name, banner);
+        if (moderators.length > 0) {
+            emit ModeratorsUpdated(id, moderators);
+        }
     }
 
-    /// @notice Update an existing board entry
-    /// @param id Identifier of the board entry
-    /// @param subject New subject
-    /// @param body New body content
-    /// @param email New contact email
-    /// @param name New display name, defaults to "Anonymous" if empty
+    /// @notice Update board metadata and moderators
+    /// @param id Board identifier
+    /// @param name New board name
+    /// @param banner New banner identifier
+    /// @param moderators New list of moderators
     function updateBoard(
         uint256 id,
-        string calldata subject,
-        string calldata body,
-        string calldata email,
-        string calldata name
+        string calldata name,
+        string calldata banner,
+        address[] calldata moderators
     ) external onlySysop {
         require(id < boardCount, "invalid board");
-        string memory finalName = bytes(name).length > 0 ? name : "Anonymous";
-        boards[id] = BoardInfo(subject, body, email, finalName);
-        emit BoardUpdated(id, subject, body, email, finalName);
+        BoardInfo storage b = boards[id];
+        b.name = name;
+        b.banner = banner;
+        delete b.moderators;
+        for (uint256 i = 0; i < moderators.length; i++) {
+            b.moderators.push(moderators[i]);
+        }
+        emit BoardUpdated(id, name, banner);
+        emit ModeratorsUpdated(id, moderators);
+    }
+
+    /// @notice Add a post to a board
+    /// @param boardId Board identifier
+    /// @param postId Post identifier
+    function addPost(uint256 boardId, uint256 postId)
+        external
+        onlySysopOrModerator(boardId)
+    {
+        require(boardId < boardCount, "invalid board");
+        boards[boardId].posts.push(Post(postId));
+        emit PostAdded(boardId, postId);
     }
 
     /// @notice Retrieve board information
-    /// @param id Identifier of the board entry
+    /// @param id Board identifier
     /// @return b Board information
     function getBoard(uint256 id) external view returns (BoardInfo memory b) {
+        require(id < boardCount, "invalid board");
         b = boards[id];
     }
 }


### PR DESCRIPTION
## Summary
- redesign Board contract to store board name, banner, posts, and moderators
- add post management and moderator-based access control

## Testing
- `solcjs --bin -o /tmp/contracts contracts/Board.sol && ls /tmp/contracts`


------
https://chatgpt.com/codex/tasks/task_e_68b4c83b5888832788ac794f98af6ea5