### PR TITLE
Update contract ABIs and addresses

### DIFF
--- a/app/abi/Board.json
+++ b/app/abi/Board.json
@@ -17,25 +17,13 @@
         {
           "indexed": false,
           "internalType": "string",
-          "name": "subject",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "body",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "email",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
           "name": "name",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "banner",
           "type": "string"
         }
       ],
@@ -54,29 +42,55 @@
         {
           "indexed": false,
           "internalType": "string",
-          "name": "subject",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "body",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "email",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
           "name": "name",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "banner",
           "type": "string"
         }
       ],
       "name": "BoardUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address[]",
+          "name": "moderators",
+          "type": "address[]"
+        }
+      ],
+      "name": "ModeratorsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostAdded",
       "type": "event"
     },
     {
@@ -99,6 +113,24 @@
       "type": "event"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "addPost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "boardCount",
       "outputs": [
@@ -114,58 +146,19 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "boards",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "subject",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "body",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "email",
-          "type": "string"
-        },
-        {
           "internalType": "string",
           "name": "name",
           "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "subject",
-          "type": "string"
         },
         {
           "internalType": "string",
-          "name": "body",
+          "name": "banner",
           "type": "string"
         },
         {
-          "internalType": "string",
-          "name": "email",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "name",
-          "type": "string"
+          "internalType": "address[]",
+          "name": "moderators",
+          "type": "address[]"
         }
       ],
       "name": "createBoard",
@@ -193,23 +186,30 @@
           "components": [
             {
               "internalType": "string",
-              "name": "subject",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "body",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "email",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
               "name": "name",
               "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "banner",
+              "type": "string"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "id",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct Board.Post[]",
+              "name": "posts",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "address[]",
+              "name": "moderators",
+              "type": "address[]"
             }
           ],
           "internalType": "struct Board.BoardInfo",
@@ -255,23 +255,18 @@
         },
         {
           "internalType": "string",
-          "name": "subject",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "body",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "email",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
           "name": "name",
           "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "banner",
+          "type": "string"
+        },
+        {
+          "internalType": "address[]",
+          "name": "moderators",
+          "type": "address[]"
         }
       ],
       "name": "updateBoard",
@@ -281,4 +276,3 @@
     }
   ]
 }
-

--- a/app/abi/CommentStorage.json
+++ b/app/abi/CommentStorage.json
@@ -1,6 +1,12 @@
 [
     {
-      "inputs": [],
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "moderationAddress",
+          "type": "address"
+        }
+      ],
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
@@ -210,6 +216,19 @@
     },
     {
       "inputs": [],
+      "name": "moderationContract",
+      "outputs": [
+        {
+          "internalType": "contract IModeration",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "nextCommentId",
       "outputs": [
         {
@@ -265,4 +284,4 @@
       "stateMutability": "nonpayable",
       "type": "function"
     }
-]
+  ]

--- a/app/abi/Comments.json
+++ b/app/abi/Comments.json
@@ -2,7 +2,16 @@
   "abi": [
     {
       "inputs": [
-        {"internalType": "address", "name": "postsAddress", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "postsAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "moderationAddress",
+          "type": "address"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
@@ -10,12 +19,42 @@
     {
       "anonymous": false,
       "inputs": [
-        {"indexed": true, "internalType": "uint256", "name": "id", "type": "uint256"},
-        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"},
-        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
-        {"indexed": false, "internalType": "string", "name": "username", "type": "string"},
-        {"indexed": false, "internalType": "string", "name": "email", "type": "string"},
-        {"indexed": false, "internalType": "string", "name": "body", "type": "string"}
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        }
       ],
       "name": "CommentAdded",
       "type": "event"
@@ -23,43 +62,162 @@
     {
       "anonymous": false,
       "inputs": [
-        {"indexed": true, "internalType": "address", "name": "previousSysop", "type": "address"},
-        {"indexed": true, "internalType": "address", "name": "newSysop", "type": "address"}
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousSysop",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
       ],
       "name": "SysopTransferred",
       "type": "event"
     },
     {
       "inputs": [
-        {"internalType": "uint256", "name": "postId", "type": "uint256"},
-        {"internalType": "string", "name": "username", "type": "string"},
-        {"internalType": "string", "name": "email", "type": "string"},
-        {"internalType": "string", "name": "body", "type": "string"}
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        }
       ],
       "name": "addComment",
       "outputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "commentCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "comments",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
       ],
       "name": "getComment",
       "outputs": [
         {
           "components": [
-            {"internalType": "address", "name": "author", "type": "address"},
-            {"internalType": "string", "name": "username", "type": "string"},
-            {"internalType": "string", "name": "email", "type": "string"},
-            {"internalType": "string", "name": "body", "type": "string"},
-            {"internalType": "uint256", "name": "postId", "type": "uint256"}
+            {
+              "internalType": "address",
+              "name": "author",
+              "type": "address"
+            },
+            {
+              "internalType": "string",
+              "name": "username",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "email",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "body",
+              "type": "string"
+            },
+            {
+              "internalType": "uint256",
+              "name": "postId",
+              "type": "uint256"
+            }
           ],
           "internalType": "struct Comments.Comment",
-          "name": "",
+          "name": "c",
           "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "moderationContract",
+      "outputs": [
+        {
+          "internalType": "contract IModeration",
+          "name": "",
+          "type": "address"
         }
       ],
       "stateMutability": "view",
@@ -69,16 +227,11 @@
       "inputs": [],
       "name": "postsContract",
       "outputs": [
-        {"internalType": "address", "name": "", "type": "address"}
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "commentCount",
-      "outputs": [
-        {"internalType": "uint256", "name": "", "type": "uint256"}
+        {
+          "internalType": "contract IPosts",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -87,25 +240,24 @@
       "inputs": [],
       "name": "sysop",
       "outputs": [
-        {"internalType": "address", "name": "", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [
-        {"internalType": "address", "name": "newSysop", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
       ],
       "name": "transferSysop",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "address", "name": "postsAddress", "type": "address"}
-      ],
-      "name": "setPostsContract",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/app/abi/Moderation.json
+++ b/app/abi/Moderation.json
@@ -1,0 +1,265 @@
+[
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "AddressBanned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "AddressUnbanned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "moderator",
+          "type": "address"
+        }
+      ],
+      "name": "ModeratorAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "moderator",
+          "type": "address"
+        }
+      ],
+      "name": "ModeratorRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostBlacklisted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostUnblacklisted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousSysop",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
+      ],
+      "name": "SysopTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "moderator",
+          "type": "address"
+        }
+      ],
+      "name": "addModerator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "banAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "blacklistPost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "isBanned",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "isModerator",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "isPostBlacklisted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "moderator",
+          "type": "address"
+        }
+      ],
+      "name": "removeModerator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sysop",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
+      ],
+      "name": "transferSysop",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "unbanAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "unblacklistPost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]

--- a/app/abi/PostStorage.json
+++ b/app/abi/PostStorage.json
@@ -1,774 +1,793 @@
 [
-  {
-    "inputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "authorInfo",
-        "type": "string"
-      }
-    ],
-    "name": "AuthorInfoUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "bannerImageId",
-        "type": "string"
-      }
-    ],
-    "name": "BannerImageSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "ImageBlacklistUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "ImageMagnetSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "PostBlacklistUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "contentHash",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "PostCreated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      }
-    ],
-    "name": "PostDeleted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousSysop",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newSysop",
-        "type": "address"
-      }
-    ],
-    "name": "SysopTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "VideoBlacklistUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "VideoMagnetSet",
-    "type": "event"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "blacklistedImages",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "blacklistedVideos",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "contentHash",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "authorInfo",
-        "type": "string"
-      },
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "magnetURI",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct PostStorage.MediaInput[]",
-        "name": "images",
-        "type": "tuple[]"
-      },
-      {
-        "internalType": "uint256",
-        "name": "bannerImageIndex",
-        "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "magnetURI",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct PostStorage.MediaInput[]",
-        "name": "videos",
-        "type": "tuple[]"
-      }
-    ],
-    "name": "createPost",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      }
-    ],
-    "name": "deletePost",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      }
-    ],
-    "name": "getImage",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      }
-    ],
-    "name": "getImageMagnet",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      }
-    ],
-    "name": "getPost",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "author",
-            "type": "address"
-          },
-          {
-            "internalType": "string",
-            "name": "contentHash",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "magnetURI",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "authorInfo",
-            "type": "string"
-          },
-          {
-            "internalType": "bool",
-            "name": "exists",
-            "type": "bool"
-          },
-          {
-            "internalType": "bool",
-            "name": "blacklisted",
-            "type": "bool"
-          },
-          {
-            "internalType": "string[]",
-            "name": "imageIds",
-            "type": "string[]"
-          },
-          {
-            "internalType": "string",
-            "name": "bannerImageId",
-            "type": "string"
-          },
-          {
-            "internalType": "string[]",
-            "name": "videoIds",
-            "type": "string[]"
-          }
-        ],
-        "internalType": "struct PostStorage.Post",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      }
-    ],
-    "name": "getVideo",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      }
-    ],
-    "name": "getVideoMagnet",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "imageMagnets",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "nextPostId",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "posts",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "internalType": "string",
-        "name": "contentHash",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "authorInfo",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "exists",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "blacklisted",
-        "type": "bool"
-      },
-      {
-        "internalType": "string",
-        "name": "bannerImageId",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      }
-    ],
-    "name": "setBannerImage",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "setBlacklist",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "setImageBlacklist",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "imageId",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "setImageMagnet",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "isBlacklisted",
-        "type": "bool"
-      }
-    ],
-    "name": "setVideoBlacklist",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "videoId",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "setVideoMagnet",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "sysop",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newSysop",
-        "type": "address"
-      }
-    ],
-    "name": "transferSysop",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "authorInfo",
-        "type": "string"
-      }
-    ],
-    "name": "updateAuthorInfo",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "videoMagnets",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "contentHash",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "PostUpdated",
-    "type": "event"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "contentHash",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "magnetURI",
-        "type": "string"
-      }
-    ],
-    "name": "updatePost",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
-]
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "moderationAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        }
+      ],
+      "name": "AuthorInfoUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "bannerImageId",
+          "type": "string"
+        }
+      ],
+      "name": "BannerImageSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "ImageBlacklistUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "ImageMagnetSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "PostBlacklistUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "contentHash",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "PostCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostDeleted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "contentHash",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "PostUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousSysop",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
+      ],
+      "name": "SysopTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "VideoBlacklistUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "VideoMagnetSet",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "blacklistedImages",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "blacklistedVideos",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "contentHash",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        },
+        {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "magnetURI",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct PostStorage.MediaInput[]",
+          "name": "images",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bannerImageIndex",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "magnetURI",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct PostStorage.MediaInput[]",
+          "name": "videos",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "createPost",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "deletePost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        }
+      ],
+      "name": "getImage",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        }
+      ],
+      "name": "getImageMagnet",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPost",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "author",
+              "type": "address"
+            },
+            {
+              "internalType": "string",
+              "name": "contentHash",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "magnetURI",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "authorInfo",
+              "type": "string"
+            },
+            {
+              "internalType": "bool",
+              "name": "exists",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "blacklisted",
+              "type": "bool"
+            },
+            {
+              "internalType": "string[]",
+              "name": "imageIds",
+              "type": "string[]"
+            },
+            {
+              "internalType": "string",
+              "name": "bannerImageId",
+              "type": "string"
+            },
+            {
+              "internalType": "string[]",
+              "name": "videoIds",
+              "type": "string[]"
+            }
+          ],
+          "internalType": "struct PostStorage.Post",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        }
+      ],
+      "name": "getVideo",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        }
+      ],
+      "name": "getVideoMagnet",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "imageMagnets",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "moderationContract",
+      "outputs": [
+        {
+          "internalType": "contract IModeration",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextPostId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "posts",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "contentHash",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "blacklisted",
+          "type": "bool"
+        },
+        {
+          "internalType": "string",
+          "name": "bannerImageId",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        }
+      ],
+      "name": "setBannerImage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "setBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "setImageBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "imageId",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "setImageMagnet",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "isBlacklisted",
+          "type": "bool"
+        }
+      ],
+      "name": "setVideoBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "videoId",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "setVideoMagnet",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sysop",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
+      ],
+      "name": "transferSysop",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        }
+      ],
+      "name": "updateAuthorInfo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "contentHash",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "magnetURI",
+          "type": "string"
+        }
+      ],
+      "name": "updatePost",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "videoMagnets",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/app/abi/Posts.json
+++ b/app/abi/Posts.json
@@ -2,7 +2,16 @@
   "abi": [
     {
       "inputs": [
-        {"internalType": "address", "name": "boardAddress", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "boardAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "moderationAddress",
+          "type": "address"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
@@ -10,13 +19,48 @@
     {
       "anonymous": false,
       "inputs": [
-        {"indexed": true, "internalType": "uint256", "name": "id", "type": "uint256"},
-        {"indexed": true, "internalType": "uint256", "name": "boardId", "type": "uint256"},
-        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
-        {"indexed": false, "internalType": "string", "name": "username", "type": "string"},
-        {"indexed": false, "internalType": "string", "name": "email", "type": "string"},
-        {"indexed": false, "internalType": "string", "name": "subject", "type": "string"},
-        {"indexed": false, "internalType": "string", "name": "body", "type": "string"}
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "subject",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        }
       ],
       "name": "PostCreated",
       "type": "event"
@@ -24,44 +68,119 @@
     {
       "anonymous": false,
       "inputs": [
-        {"indexed": true, "internalType": "address", "name": "previousSysop", "type": "address"},
-        {"indexed": true, "internalType": "address", "name": "newSysop", "type": "address"}
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousSysop",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
       ],
       "name": "SysopTransferred",
       "type": "event"
     },
     {
+      "inputs": [],
+      "name": "boardContract",
+      "outputs": [
+        {
+          "internalType": "contract IBoard",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
-        {"internalType": "uint256", "name": "boardId", "type": "uint256"},
-        {"internalType": "string", "name": "username", "type": "string"},
-        {"internalType": "string", "name": "email", "type": "string"},
-        {"internalType": "string", "name": "subject", "type": "string"},
-        {"internalType": "string", "name": "body", "type": "string"}
+        {
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "subject",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        }
       ],
       "name": "createPost",
       "outputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
       ],
       "name": "getPost",
       "outputs": [
         {
           "components": [
-            {"internalType": "address", "name": "author", "type": "address"},
-            {"internalType": "string", "name": "username", "type": "string"},
-            {"internalType": "string", "name": "email", "type": "string"},
-            {"internalType": "string", "name": "subject", "type": "string"},
-            {"internalType": "string", "name": "body", "type": "string"},
-            {"internalType": "uint256", "name": "boardId", "type": "uint256"}
+            {
+              "internalType": "address",
+              "name": "author",
+              "type": "address"
+            },
+            {
+              "internalType": "string",
+              "name": "username",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "email",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "subject",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "body",
+              "type": "string"
+            },
+            {
+              "internalType": "uint256",
+              "name": "boardId",
+              "type": "uint256"
+            }
           ],
           "internalType": "struct Posts.Post",
-          "name": "",
+          "name": "p",
           "type": "tuple"
         }
       ],
@@ -70,9 +189,13 @@
     },
     {
       "inputs": [],
-      "name": "boardContract",
+      "name": "moderationContract",
       "outputs": [
-        {"internalType": "address", "name": "", "type": "address"}
+        {
+          "internalType": "contract IModeration",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -81,7 +204,55 @@
       "inputs": [],
       "name": "postCount",
       "outputs": [
-        {"internalType": "uint256", "name": "", "type": "uint256"}
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "posts",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "author",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "email",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "subject",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "boardId",
+          "type": "uint256"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -90,25 +261,24 @@
       "inputs": [],
       "name": "sysop",
       "outputs": [
-        {"internalType": "address", "name": "", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [
-        {"internalType": "address", "name": "newSysop", "type": "address"}
+        {
+          "internalType": "address",
+          "name": "newSysop",
+          "type": "address"
+        }
       ],
       "name": "transferSysop",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "address", "name": "boardAddress", "type": "address"}
-      ],
-      "name": "setBoardContract",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/app/settings.py
+++ b/app/settings.py
@@ -159,24 +159,28 @@ class Settings:
     ABI_PATH = Path(__file__).resolve().parent / "abi"
     BLOCKCHAIN_CONTRACTS = {
         "Board": {
-            "address": "0x58A0Df72EF0195A2Ce115F0379dA0d4b5833B5b4",
+            "address": "0xe20Ba14058a6De592Ff9309A2B0D3B1c7cD18FB8",
             "abi": json.loads((ABI_PATH / "Board.json").read_text()),
         },
         "Posts": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0xD594bf9FcfC4dD9A6dA8f65D5E29D9f71302a34E",
             "abi": json.loads((ABI_PATH / "Posts.json").read_text()),
         },
         "Comments": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0x22EBB7E5Fa8b5E03f19F68f7F3925Bf84166F656",
             "abi": json.loads((ABI_PATH / "Comments.json").read_text()),
         },
         "PostStorage": {
-            "address": "0x73625B5ef40e8254E65179aBdD393733f6901A18",
+            "address": "0x1785Fa13F4b1cA4e512dBa71e213c86D0E019c91",
             "abi": json.loads((ABI_PATH / "PostStorage.json").read_text()),
         },
         "CommentStorage": {
-            "address": "0x96D82416251c601a285bA0eB92Df8b8A8E695Bc4",
+            "address": "0xCdB9Abfe1E5cc4Fba0E242F78Ddb0B37F85E5077",
             "abi": json.loads((ABI_PATH / "CommentStorage.json").read_text()),
+        },
+        "Moderation": {
+            "address": "0x3D44eE9487Bf815Fe9c0F619F415FDc32afb4170",
+            "abi": json.loads((ABI_PATH / "Moderation.json").read_text()),
         },
         "SponsorSlots": {
             "address": "0x4c01F8E45a0523e4B2f485dF47D35f7803e46f4D",


### PR DESCRIPTION
## Summary
- refresh ABI definitions for board, posts, comments, and storage contracts
- add moderation contract ABI and wire up all new addresses in settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4cb0e3d248327b5ac562a439ffc6a