### PR TITLE
feat: add generic smart contract API

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -98,6 +98,7 @@ from routes.setTheme import (
 from routes.user import userBlueprint
 from routes.comments import commentsBlueprint
 from routes.api import apiBlueprint
+from routes.contracts import contractsBlueprint
 from settings import Settings
 from utils.afterRequest import (
     afterRequestLogger,
@@ -307,6 +308,7 @@ app.register_blueprint(boardBlueprint)
 app.register_blueprint(forumBlueprint)
 app.register_blueprint(commentsBlueprint)
 app.register_blueprint(apiBlueprint)
+app.register_blueprint(contractsBlueprint)
 
 
 if __name__ == "__main__":

--- a/app/routes/contracts.py
+++ b/app/routes/contracts.py
@@ -1,0 +1,54 @@
+"""Blueprint providing generic smart contract interaction endpoints."""
+from flask import Blueprint, jsonify, request
+from settings import Settings
+from web3 import Web3
+import json
+
+contractsBlueprint = Blueprint("contracts", __name__, url_prefix="/api/v1/contracts")
+
+
+@contractsBlueprint.route("", methods=["GET"])
+def list_contracts():
+    """Return available smart contract addresses."""
+    contracts = {
+        name: {"address": info.get("address", "")}
+        for name, info in Settings.BLOCKCHAIN_CONTRACTS.items()
+    }
+    return jsonify(contracts)
+
+
+@contractsBlueprint.route("/<string:contract_name>", methods=["GET"])
+def get_contract(contract_name):
+    """Return address and ABI for a specific contract."""
+    info = Settings.BLOCKCHAIN_CONTRACTS.get(contract_name)
+    if not info:
+        return jsonify({"error": "Unknown contract"}), 404
+    return jsonify({"address": info.get("address", ""), "abi": info.get("abi", [])})
+
+
+@contractsBlueprint.route("/<string:contract_name>/<string:method>", methods=["POST"])
+def interact(contract_name, method):
+    """Interact with a contract method using call or transact."""
+    info = Settings.BLOCKCHAIN_CONTRACTS.get(contract_name)
+    if not info:
+        return jsonify({"error": "Unknown contract"}), 404
+
+    payload = request.get_json(silent=True) or {}
+    params = payload.get("params", [])
+    tx_options = payload.get("txOptions", {})
+    action = payload.get("action", "call")
+
+    w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
+    contract = w3.eth.contract(address=info["address"], abi=info["abi"])
+    func = getattr(contract.functions, method, None)
+    if func is None:
+        return jsonify({"error": "Unknown function"}), 400
+
+    try:
+        if action == "transact":
+            tx_hash = func(*params).transact(tx_options)
+            return jsonify({"txHash": tx_hash.hex()})
+        result = func(*params).call(tx_options)
+        return jsonify({"result": json.loads(Web3.to_json(result))})
+    except Exception as exc:  # pragma: no cover - external call
+        return jsonify({"error": str(exc)}), 500


### PR DESCRIPTION
## Summary
- introduce contracts API blueprint for listing contracts, fetching ABI, and executing calls or transactions
- register contracts blueprint in app initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4cfac79048327bce902530ec93f69