### PR TITLE
Expose admin contract management API

### DIFF
--- a/app/routes/adminPanelContracts.py
+++ b/app/routes/adminPanelContracts.py
@@ -1,30 +1,99 @@
-from flask import Blueprint, redirect, render_template, request, session
+"""Admin endpoints for managing and interacting with smart contracts.
+
+This blueprint mirrors the generic contract interaction endpoints exposed under
+``/api/v1/contracts`` but restricts access to authenticated administrators. It
+also keeps the previous ability for admins to update contract addresses.
+"""
+
+from flask import Blueprint, jsonify, redirect, request, session
 from settings import Settings
 from utils.log import Log
+from web3 import Web3
+import json
+
 
 adminPanelContractsBlueprint = Blueprint("adminPanelContracts", __name__)
 
+
+def _is_admin() -> bool:
+    """Return True if the current session belongs to an admin user."""
+    return "walletAddress" in session and session.get("userRole") == "admin"
+
+
 @adminPanelContractsBlueprint.route("/admin/contracts", methods=["GET", "POST"])
-def adminPanelContracts():
-    if "walletAddress" in session and session.get("userRole") == "admin":
-        if request.method == "POST":
-            if "contractUpdateButton" in request.form:
-                name = request.form.get("contractName")
-                address = request.form.get("contractAddress")
-                if name in Settings.BLOCKCHAIN_CONTRACTS:
-                    Log.info(
-                        f"Admin: {session['walletAddress']} updated address for {name}"
-                    )
-                    Settings.BLOCKCHAIN_CONTRACTS[name]["address"] = address
-        Log.info("Rendering adminPanelContracts.html")
-        return render_template(
-            "adminPanelContracts.html",
-            contracts=Settings.BLOCKCHAIN_CONTRACTS,
-            admin_check=True,
-            rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+def list_or_update_contracts():
+    """List known contracts or allow admins to update contract addresses."""
+    if not _is_admin():
+        Log.error(
+            f"{request.remote_addr} tried to reach contracts admin panel without being admin"
         )
-    Log.error(
-        f"{request.remote_addr} tried to reach contracts admin panel without being admin"
-    )
-    return redirect(f"/login?redirect={request.path}")
+        return redirect(f"/login?redirect={request.path}")
+
+    if request.method == "POST" and "contractUpdateButton" in request.form:
+        name = request.form.get("contractName")
+        address = request.form.get("contractAddress")
+        if name in Settings.BLOCKCHAIN_CONTRACTS:
+            Log.info(
+                f"Admin: {session['walletAddress']} updated address for {name}"
+            )
+            Settings.BLOCKCHAIN_CONTRACTS[name]["address"] = address
+
+    contracts = {
+        name: {"address": info.get("address", "")}
+        for name, info in Settings.BLOCKCHAIN_CONTRACTS.items()
+    }
+    return jsonify(contracts)
+
+
+@adminPanelContractsBlueprint.route(
+    "/admin/contracts/<string:contract_name>", methods=["GET"]
+)
+def get_contract(contract_name: str):
+    """Return address and ABI for a specific contract."""
+    if not _is_admin():
+        Log.error(
+            f"{request.remote_addr} tried to reach contracts admin panel without being admin"
+        )
+        return redirect(f"/login?redirect={request.path}")
+
+    info = Settings.BLOCKCHAIN_CONTRACTS.get(contract_name)
+    if not info:
+        return jsonify({"error": "Unknown contract"}), 404
+    return jsonify({"address": info.get("address", ""), "abi": info.get("abi", [])})
+
+
+@adminPanelContractsBlueprint.route(
+    "/admin/contracts/<string:contract_name>/<string:method>", methods=["POST"]
+)
+def interact(contract_name: str, method: str):
+    """Interact with a contract method using call or transact."""
+    if not _is_admin():
+        Log.error(
+            f"{request.remote_addr} tried to reach contracts admin panel without being admin"
+        )
+        return redirect(f"/login?redirect={request.path}")
+
+    info = Settings.BLOCKCHAIN_CONTRACTS.get(contract_name)
+    if not info:
+        return jsonify({"error": "Unknown contract"}), 404
+
+    payload = request.get_json(silent=True) or {}
+    params = payload.get("params", [])
+    tx_options = payload.get("txOptions", {})
+    action = payload.get("action", "call")
+
+    w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
+    contract = w3.eth.contract(address=info["address"], abi=info["abi"])
+    func = getattr(contract.functions, method, None)
+    if func is None:
+        return jsonify({"error": "Unknown function"}), 400
+
+    try:
+        if action == "transact":
+            tx_hash = func(*params).transact(tx_options)
+            return jsonify({"txHash": tx_hash.hex()})
+        result = func(*params).call(tx_options)
+        return jsonify({"result": json.loads(Web3.to_json(result))})
+    except Exception as exc:  # pragma: no cover - external call
+        return jsonify({"error": str(exc)}), 500
 


### PR DESCRIPTION
## Summary
- document admin functions across smart contracts
- expose authenticated contract interaction endpoints at `/admin/contracts`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d154340c8327a4e2ab7b890954ff