### PR TITLE
Add board, post, and comment contract interactions in admin panel

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -73,6 +73,8 @@ from routes.passwordReset import (
 from routes.post import postBlueprint
 from routes.board import boardBlueprint
 from routes.forum import forumBlueprint
+from routes.boards import boardsBlueprint
+from routes.posts import postsBlueprint
 from routes.postStats import postStatsBlueprint
 from routes.postsAnalytics import (
     analyticsBlueprint,
@@ -306,6 +308,8 @@ app.register_blueprint(postStatsBlueprint)
 app.register_blueprint(adminPanelActivityBlueprint)
 app.register_blueprint(boardBlueprint)
 app.register_blueprint(forumBlueprint)
+app.register_blueprint(boardsBlueprint)
+app.register_blueprint(postsBlueprint)
 app.register_blueprint(commentsBlueprint)
 app.register_blueprint(apiBlueprint)
 app.register_blueprint(contractsBlueprint)

--- a/app/routes/boards.py
+++ b/app/routes/boards.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, jsonify, request
+from settings import Settings
+from web3 import Web3
+
+boardsBlueprint = Blueprint("boards", __name__)
+
+
+@boardsBlueprint.route("/api/v1/boards", methods=["POST"])
+def create_board():
+    """Create a new board via the Board contract."""
+    data = request.get_json(silent=True) or {}
+    name = data.get("name")
+    banner = data.get("banner", "")
+    moderators = data.get("moderators", [])
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+
+    contract_info = Settings.BLOCKCHAIN_CONTRACTS["Board"]
+    w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
+    contract = w3.eth.contract(address=contract_info["address"], abi=contract_info["abi"])
+    try:
+        tx_hash = contract.functions.createBoard(name, banner, moderators).transact()
+        return jsonify({"txHash": tx_hash.hex()}), 200
+    except Exception as exc:  # pragma: no cover - external call
+        return jsonify({"error": str(exc)}), 500

--- a/app/routes/posts.py
+++ b/app/routes/posts.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, jsonify, request
+from settings import Settings
+from web3 import Web3
+
+postsBlueprint = Blueprint("posts", __name__)
+
+
+@postsBlueprint.route("/api/v1/posts", methods=["POST"])
+def create_post():
+    """Create a new post via the Posts contract."""
+    data = request.get_json(silent=True) or {}
+    board_id = data.get("boardId")
+    username = data.get("username", "")
+    email = data.get("email", "")
+    subject = data.get("subject", "")
+    body = data.get("body")
+    if board_id is None or body is None:
+        return jsonify({"error": "boardId and body are required"}), 400
+
+    contract_info = Settings.BLOCKCHAIN_CONTRACTS["Posts"]
+    w3 = Web3(Web3.HTTPProvider(Settings.BLOCKCHAIN_RPC_URL))
+    contract = w3.eth.contract(address=contract_info["address"], abi=contract_info["abi"])
+    try:
+        tx_hash = contract.functions.createPost(
+            board_id, username, email, subject, body
+        ).transact()
+        return jsonify({"txHash": tx_hash.hex()}), 200
+    except Exception as exc:  # pragma: no cover - external call
+        return jsonify({"error": str(exc)}), 500

--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -23,13 +23,27 @@
             m.calls++;
             const method = form.dataset.method;
             const action = form.dataset.action;
-            const params = Array.from(form.querySelectorAll('input')).map((inp) => inp.value);
+            const paramInputs = Array.from(form.querySelectorAll('input[name^="arg"]'));
+            const params = paramInputs.map((inp) => inp.value);
+            const txOptField = form.querySelector('[name="txOptions"]');
+            let txOptions = {};
+            if (txOptField && txOptField.value.trim()) {
+                try {
+                    txOptions = JSON.parse(txOptField.value);
+                } catch (err) {
+                    m.failures++;
+                    const resultDiv = form.nextElementSibling;
+                    resultDiv.textContent = `Error: invalid txOptions JSON`;
+                    updateMetrics();
+                    return;
+                }
+            }
             const resultDiv = form.nextElementSibling;
             try {
                 const res = await fetch(`/admin/contracts/${contract}/${method}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ params, action }),
+                    body: JSON.stringify({ params, action, txOptions }),
                 });
                 const data = await res.json();
                 if (data.error) {

--- a/app/templates/adminPanelContracts.html
+++ b/app/templates/adminPanelContracts.html
@@ -47,6 +47,14 @@
                         class="input input-bordered mb-2"
                     />
                     {% endfor %}
+                    {% if fn.stateMutability not in ['view', 'pure'] %}
+                    <textarea
+                        name="txOptions"
+                        placeholder='{"from": "0x..."}'
+                        class="textarea textarea-bordered mb-2"
+                        rows="2"
+                    ></textarea>
+                    {% endif %}
                     <button type="submit" class="btn btn-sm btn-neutral">
                         {{ 'Call' if fn.stateMutability in ['view', 'pure'] else 'Send' }}
                     </button>


### PR DESCRIPTION
## Summary
- allow specifying tx options when invoking smart contracts in /admin/contracts
- support state-changing calls for Board, Posts, and Comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d7c4a92883279ae3ad5e902efa23