### PR TITLE
Enable admin contract panel for board, posts, and comments

### DIFF
--- a/app/routes/adminPanelContracts.py
+++ b/app/routes/adminPanelContracts.py
@@ -87,7 +87,16 @@ def interact(contract_name: str, method: str):
         return jsonify({"error": "Unknown contract"}), 404
 
     payload = request.get_json(silent=True) or {}
-    params = payload.get("params", [])
+    raw_params = payload.get("params", [])
+    params = []
+    for p in raw_params:
+        if isinstance(p, str):
+            try:
+                params.append(json.loads(p))
+                continue
+            except json.JSONDecodeError:
+                pass
+        params.append(p)
     tx_options = payload.get("txOptions", {})
     action = payload.get("action", "call")
 

--- a/app/routes/contracts.py
+++ b/app/routes/contracts.py
@@ -34,7 +34,16 @@ def interact(contract_name, method):
         return jsonify({"error": "Unknown contract"}), 404
 
     payload = request.get_json(silent=True) or {}
-    params = payload.get("params", [])
+    raw_params = payload.get("params", [])
+    params = []
+    for p in raw_params:
+        if isinstance(p, str):
+            try:
+                params.append(json.loads(p))
+                continue
+            except json.JSONDecodeError:
+                pass
+        params.append(p)
     tx_options = payload.get("txOptions", {})
     action = payload.get("action", "call")
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -157,38 +157,46 @@ class Settings:
     ADMIN_WALLET_ADDRESS = "0xB2b36AaD18d7be5d4016267BC4cCec2f12a64b6e"
     # Addresses and ABIs for individual smart contracts managed by the sysop
     ABI_PATH = Path(__file__).resolve().parent / "abi"
+
+    @staticmethod
+    def _load_abi(file_name: str):
+        """Return the ABI list from ``file_name`` regardless of artifact format."""
+        path = Path(__file__).resolve().parent / "abi" / file_name
+        data = json.loads(path.read_text())
+        return data.get("abi", data) if isinstance(data, dict) else data
+
     BLOCKCHAIN_CONTRACTS = {
         "Board": {
             "address": "0xe20Ba14058a6De592Ff9309A2B0D3B1c7cD18FB8",
-            "abi": json.loads((ABI_PATH / "Board.json").read_text()),
+            "abi": _load_abi("Board.json"),
         },
         "Posts": {
             "address": "0xD594bf9FcfC4dD9A6dA8f65D5E29D9f71302a34E",
-            "abi": json.loads((ABI_PATH / "Posts.json").read_text()),
+            "abi": _load_abi("Posts.json"),
         },
         "Comments": {
             "address": "0x22EBB7E5Fa8b5E03f19F68f7F3925Bf84166F656",
-            "abi": json.loads((ABI_PATH / "Comments.json").read_text()),
+            "abi": _load_abi("Comments.json"),
         },
         "PostStorage": {
             "address": "0x1785Fa13F4b1cA4e512dBa71e213c86D0E019c91",
-            "abi": json.loads((ABI_PATH / "PostStorage.json").read_text()),
+            "abi": _load_abi("PostStorage.json"),
         },
         "CommentStorage": {
             "address": "0xCdB9Abfe1E5cc4Fba0E242F78Ddb0B37F85E5077",
-            "abi": json.loads((ABI_PATH / "CommentStorage.json").read_text()),
+            "abi": _load_abi("CommentStorage.json"),
         },
         "Moderation": {
             "address": "0x3D44eE9487Bf815Fe9c0F619F415FDc32afb4170",
-            "abi": json.loads((ABI_PATH / "Moderation.json").read_text()),
+            "abi": _load_abi("Moderation.json"),
         },
         "SponsorSlots": {
             "address": "0x4c01F8E45a0523e4B2f485dF47D35f7803e46f4D",
-            "abi": json.loads((ABI_PATH / "SponsorSlots.json").read_text()),
+            "abi": _load_abi("SponsorSlots.json"),
         },
         "TipJar": {
             "address": "0x2c99CD9A504E01bb0d68540446B57c9582456931",
-            "abi": json.loads((ABI_PATH / "TipJar.json").read_text()),
+            "abi": _load_abi("TipJar.json"),
         },
     }
 

--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -24,7 +24,14 @@
             const method = form.dataset.method;
             const action = form.dataset.action;
             const paramInputs = Array.from(form.querySelectorAll('input[name^="arg"]'));
-            const params = paramInputs.map((inp) => inp.value);
+            const params = paramInputs.map((inp) => {
+                const val = inp.value.trim();
+                try {
+                    return JSON.parse(val);
+                } catch {
+                    return val;
+                }
+            });
             const txOptField = form.querySelector('[name="txOptions"]');
             let txOptions = {};
             if (txOptField && txOptField.value.trim()) {


### PR DESCRIPTION
## Summary
- Load ABI lists regardless of artifact format
- Ensure Board, Posts, and Comments contracts expose interactive admin forms alongside existing contracts

## Testing
- `python -m py_compile app/settings.py app/routes/adminPanelContracts.py app/routes/contracts.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4daf49bd083279c3682a704b9391d