### PR TITLE
fix(admin): require wallet for contract transactions

### DIFF
--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -48,6 +48,28 @@
                     return;
                 }
             }
+            if (action === 'transact') {
+                if (!txOptions.from) {
+                    if (window.userAddress) {
+                        txOptions.from = window.userAddress;
+                    } else if (window.ethereum) {
+                        try {
+                            const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+                            txOptions.from = accounts[0];
+                            window.userAddress = accounts[0];
+                        } catch (err) {
+                            debug('Wallet request failed', err);
+                        }
+                    }
+                    if (!txOptions.from) {
+                        m.failures++;
+                        const resultDiv = form.nextElementSibling;
+                        resultDiv.textContent = 'Error: wallet not connected';
+                        updateMetrics();
+                        return;
+                    }
+                }
+            }
             const resultDiv = form.nextElementSibling;
             try {
                 const res = await fetch(`/admin/contracts/${contract}/${method}`, {


### PR DESCRIPTION
## Summary
- use connected wallet address for admin contract transactions
- prompt for wallet connection when sending transactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e0667dd083279273c868e249c602