### PR TITLE
Handle seeding errors for uploads

### DIFF
--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -26,8 +26,11 @@ def createPost():
         filename = secure_filename(image.filename)
         image_path = os.path.join(images_dir, filename)
         image.save(image_path)
+        try:
+            magnet = seed_file(image_path)
+        except Exception as e:  # pragma: no cover - seeding failure
+            return jsonify({"error": str(e)}), 500
 
-        magnet = seed_file(image_path)
         ensure_seeding(images_dir)
         return jsonify({"magnet": magnet})
 
@@ -67,8 +70,11 @@ def upload_media():
     filename = secure_filename(file.filename)
     media_path = os.path.join(media_dir, filename)
     file.save(media_path)
+    try:
+        magnet = seed_file(media_path)
+    except Exception as e:  # pragma: no cover - seeding failure
+        return jsonify({"error": str(e)}), 500
 
-    magnet = seed_file(media_path)
     ensure_seeding(media_dir)
     return jsonify({"magnet": magnet})
 

--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -29,6 +29,17 @@ def seed_file(file_path: str) -> str:
     assert proc.stdout is not None
     magnet = proc.stdout.readline().strip()
     proc.stdout.close()
+
+    # ``magnet`` will be empty if the seeding process failed before
+    # printing the magnet URI.  This commonly happens when the WebTorrent
+    # CLI is not installed or exits with an error.  Surfacing a helpful
+    # exception allows callers to report a meaningful message instead of
+    # silently returning an empty string which later triggers a generic
+    # "upload failed" error in the UI.
+    if not magnet:
+        proc.wait()  # reap the worker to avoid zombies
+        raise RuntimeError("failed to seed file – is webtorrent installed?")
+
     return magnet
 
 


### PR DESCRIPTION
## Summary
- ensure torrent seeding failures raise a clear error
- return seeding failures as JSON errors for uploads

## Testing
- `pytest`
- `python -m py_compile app/utils/torrent.py app/routes/createPost.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e439bc5c8327a4253b7ea201ee04