### PR TITLE
Seed uploaded images with WebTorrent

### DIFF
--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -47,6 +47,16 @@
                 fileInput.className = 'file-input file-input-bordered mb-2';
                 inp.insertAdjacentElement('afterend', fileInput);
                 inp.dataset.fileInput = 'true';
+
+                fileInput.addEventListener('change', async () => {
+                    if (!fileInput.files.length) return;
+                    try {
+                        const magnet = await uploadFile(fileInput.files[0]);
+                        inp.value = magnet;
+                    } catch (err) {
+                        console.error('upload failed', err);
+                    }
+                });
             }
         });
 

--- a/app/utils/torrent_worker.py
+++ b/app/utils/torrent_worker.py
@@ -31,7 +31,12 @@ def seed(file_path: str) -> None:
     assert proc.stdout is not None
     magnet_printed = False
     for line in proc.stdout:
-        if not magnet_printed and line.startswith("Magnet:"):
+        if magnet_printed:
+            continue
+        if "Magnet URI:" in line:
+            print(line.split("Magnet URI:")[1].strip(), flush=True)
+            magnet_printed = True
+        elif "Magnet:" in line:
             print(line.split("Magnet:")[1].strip(), flush=True)
             magnet_printed = True
 


### PR DESCRIPTION
## Summary
- capture WebTorrent magnet links even when CLI prints "Magnet URI:" output
- automatically upload selected banner images on admin contract forms and fill inputs with returned magnet links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e8e3d42c83278f5b710a24af42fe