### PR TITLE
Install WebTorrent CLI in application container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY app /app
-# Install dependencies using uv if available, fall back to pip
+# Install Node.js and WebTorrent CLI
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
+    npm install -g webtorrent-cli && \
+    rm -rf /var/lib/apt/lists/*
+# Install Python dependencies using uv if available, fall back to pip
 RUN (pip install --no-cache-dir uv && uv pip install --system -r requirements.txt) || \
     pip install --no-cache-dir -r requirements.txt
 EXPOSE 80


### PR DESCRIPTION
## Summary
- Install Node.js and webtorrent-cli in the Docker image

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68b4ebe405f88327926ad49b27c653c7