### PR TITLE
Fix contract reads to use connected wallet

### DIFF
--- a/app/static/js/adminContracts.js
+++ b/app/static/js/adminContracts.js
@@ -114,7 +114,9 @@
                     m.successes++;
                     resultDiv.textContent = `Tx: ${receipt.transactionHash}`;
                 } else {
-                    const provider = window.rpcUrl
+                    const provider = window.ethereum
+                        ? new ethers.providers.Web3Provider(window.ethereum)
+                        : window.rpcUrl
                         ? new ethers.providers.JsonRpcProvider(window.rpcUrl)
                         : ethers.getDefaultProvider();
                     const ctr = new ethers.Contract(info.address, info.abi, provider);


### PR DESCRIPTION
## Summary
- Use browser wallet provider for non-transacting reads so calls hit the same network as metamask

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4f260de5c83278f4f367e1676c1b7