### PR TITLE
Add email-validator dependency to sanitizer service

### DIFF
--- a/sanitizer/requirements.txt
+++ b/sanitizer/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.30.6
 httpx==0.27.0
 bleach==6.1.0
 pydantic==2.8.2
+email-validator==2.3.0
 python-multipart==0.0.9
 PyYAML==6.0.2
 regex==2024.7.24


### PR DESCRIPTION
## Summary
- add `email-validator` to sanitizer requirements to enable Pydantic email validation

## Testing
- `pip install -r sanitizer/requirements.txt`
- `python -m py_compile sanitizer/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f51347348327b040aa2535cfe362