### PR TITLE
Fix BunkerWeb DB initialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - bw-data:/var/lib/bunkerweb
     command: >
-      /bin/sh -c "touch /var/lib/bunkerweb/db.sqlite3 && chown 101:101 /var/lib/bunkerweb/db.sqlite3 && /entrypoint.sh"
+      /bin/sh -c "chown -R 101:101 /var/lib/bunkerweb && /entrypoint.sh"
     depends_on:
       - sanitizer
   bunkerweb-ui:


### PR DESCRIPTION
## Summary
- ensure BunkerWeb can create its SQLite DB by chowning the volume instead of touching the file

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b50052942483278a54fd9c782e6c88