### PR TITLE
feat: parameterize domain via env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DOMAIN=localhost

--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ Visit `http://localhost:1283` in your browser.
 Run the full stack with Docker:
 
 ```bash
+cp .env.example .env
+# edit DOMAIN in .env if you want BunkerWeb to answer on a custom domain
 docker compose up --build
 ```
 
 BunkerWeb exposes the application on port `80`, and its management UI is
-available on port `8000`.
+available on port `8000`. The `DOMAIN` value defines which Host header
+BunkerWeb accepts.
 
 ### Blockchain
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - "80:80"
     environment:
-      - SERVER_NAME=_
+      - SERVER_NAME=${DOMAIN:-localhost}
       - PROXY_PASS=http://sanitizer:8080
       - USE_DB=true
     volumes:


### PR DESCRIPTION
## Summary
- allow configuring BunkerWeb's SERVER_NAME via DOMAIN environment variable
- document domain configuration and add .env example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5021cd4f483278f1660a5b900292a