### PR TITLE
Add gateway proxy and honeypot routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ cp .env.example .env
 docker compose up --build
 ```
 
-BunkerWeb exposes the application on port `80`, and its management UI is
+The `gateway` service now listens on port `80` and decides whether to send
+traffic to BunkerWeb or to an [annoying honeypot](https://github.com/feross/TheAnnoyingSite.com)
+based on a simple user‑agent check. BunkerWeb's management UI is still
 available on port `8000`. The `DOMAIN` value defines which Host header
-BunkerWeb accepts.
+the stack accepts.
 
 ### Blockchain
 

--- a/annoyingsite/Dockerfile
+++ b/annoyingsite/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+RUN apk add --no-cache git \
+    && git clone https://github.com/feross/TheAnnoyingSite.com /app
+WORKDIR /app
+RUN npm install
+EXPOSE 4000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       - web
   bunkerweb:
     image: bunkerity/bunkerweb:latest
-    ports:
-      - "80:8080"
+    expose:
+      - "8080"
     environment:
       - API_WHITELIST_IP=0.0.0.0/0
     volumes:
@@ -61,6 +61,20 @@ services:
       - bw-data:/var/lib/bunkerweb
     depends_on:
       - bunkerweb-scheduler
+  annoyingsite:
+    build: ./annoyingsite
+    expose:
+      - "4000"
+  gateway:
+    build: ./gateway
+    ports:
+      - "80:80"
+    environment:
+      - BUNKER_URL=http://bunkerweb:8080
+      - ANNOY_URL=http://annoyingsite:4000
+    depends_on:
+      - bunkerweb
+      - annoyingsite
 
 volumes:
   bw-data:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 80
+CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,0 +1,35 @@
+import os
+from flask import Flask, request, Response
+import requests
+
+app = Flask(__name__)
+
+BUNKER_URL = os.environ.get('BUNKER_URL', 'http://bunkerweb:8080')
+ANNOY_URL = os.environ.get('ANNOY_URL', 'http://annoyingsite:4000')
+
+
+def is_malicious(req):
+    ua = req.headers.get('User-Agent', '').lower()
+    return 'curl' in ua or 'python-requests' in ua
+
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
+def proxy(path):
+    target = ANNOY_URL if is_malicious(request) else BUNKER_URL
+    url = f"{target}/{path}"
+    resp = requests.request(
+        method=request.method,
+        url=url,
+        headers={k: v for k, v in request.headers if k.lower() != 'host'},
+        data=request.get_data(),
+        cookies=request.cookies,
+        allow_redirects=False,
+    )
+    excluded = {'content-encoding', 'content-length', 'transfer-encoding', 'connection'}
+    headers = [(name, value) for name, value in resp.raw.headers.items() if name.lower() not in excluded]
+    return Response(resp.content, resp.status_code, headers)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=80)

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+requests
+gunicorn


### PR DESCRIPTION
## Summary
- add Python-based gateway service to filter requests and proxy to BunkerWeb or AnnoyingSite
- add AnnoyingSite container as honeypot
- update docker-compose and docs to use new gateway front-end

## Testing
- `python -m py_compile gateway/app.py`
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_68b50b190ac88327ba45a82156c256c5