### PR TITLE
Add ClamAV and Coraza plugins for BunkerWeb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       /bin/sh -c "chown -R 101:101 /var/lib/bunkerweb && /entrypoint.sh"
     depends_on:
       - sanitizer
+    networks:
+      - default
+      - bw-plugins
   bunkerweb-scheduler:
     image: bunkerity/bunkerweb-scheduler:latest
     environment:
@@ -47,10 +50,19 @@ services:
       - REVERSE_PROXY_HOST=http://sanitizer:8080
       - USE_DB=true
       - API_WHITELIST_IP=0.0.0.0/0
+      - HTTP2=no
+      - USE_MODSECURITY=no
+      - USE_CORAZA=yes
+      - CORAZA_API=http://bw-coraza:8080
+      - USE_CLAMAV=yes
+      - CLAMAV_HOST=clamav
     volumes:
       - bw-data:/data
     depends_on:
       - bunkerweb
+    networks:
+      - default
+      - bw-plugins
   bunkerweb-ui:
     image: bunkerity/bunkerweb-ui:latest
     ports:
@@ -75,6 +87,19 @@ services:
     depends_on:
       - bunkerweb
       - annoyingsite
+  clamav:
+    image: clamav/clamav:1.4
+    volumes:
+      - ./clamav-data:/var/lib/clamav
+    networks:
+      - bw-plugins
+  bw-coraza:
+    image: bunkerity/bunkerweb-coraza:latest
+    networks:
+      - bw-plugins
 
 volumes:
   bw-data:
+networks:
+  bw-plugins:
+    name: bw-plugins


### PR DESCRIPTION
## Summary
- integrate ClamAV and Coraza plugins into BunkerWeb stack
- add ClamAV and Coraza services and scheduler settings

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ed78ac48327bd19be467e51e817