### PR TITLE
Forward fail2ban bans to annoyingsite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,9 +84,19 @@ services:
     environment:
       - BUNKER_URL=http://bunkerweb:8080
       - ANNOY_URL=http://annoyingsite:4000
+      - BANNED_IPS_FILE=/banned/banned_ips.list
+    volumes:
+      - ./banned:/banned
     depends_on:
       - bunkerweb
       - annoyingsite
+  fail2ban:
+    image: crazymax/fail2ban:latest
+    volumes:
+      - ./fail2ban:/etc/fail2ban
+      - ./banned:/banned
+    depends_on:
+      - gateway
   clamav:
     image: clamav/clamav:1.4
     volumes:

--- a/fail2ban/action.d/annoyingsite.conf
+++ b/fail2ban/action.d/annoyingsite.conf
@@ -1,0 +1,8 @@
+[Definition]
+actionstart =
+actionstop =
+actionban = echo <ip> >> %(file)s
+actionunban = sed -i '/^<ip>$/d' %(file)s
+
+[Init]
+file = /banned/banned_ips.list

--- a/fail2ban/filter.d/annoyingsite.conf
+++ b/fail2ban/filter.d/annoyingsite.conf
@@ -1,0 +1,2 @@
+[Definition]
+failregex = ^<HOST> -.*$

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -1,0 +1,7 @@
+[annoyingsite]
+enabled = true
+port = http,https
+filter = annoyingsite
+logpath = /var/log/gateway/access.log
+maxretry = 1
+action = annoyingsite[file=/banned/banned_ips.list]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -4,13 +4,26 @@ import requests
 
 app = Flask(__name__)
 
-BUNKER_URL = os.environ.get('BUNKER_URL', 'http://bunkerweb:8080')
-ANNOY_URL = os.environ.get('ANNOY_URL', 'http://annoyingsite:4000')
+BUNKER_URL = os.environ.get("BUNKER_URL", "http://bunkerweb:8080")
+ANNOY_URL = os.environ.get("ANNOY_URL", "http://annoyingsite:4000")
+BANNED_IPS_FILE = os.environ.get("BANNED_IPS_FILE", "/banned/banned_ips.list")
+
+
+def is_ip_banned(ip: str) -> bool:
+    """Check if the given IP is listed in the fail2ban banned file."""
+    try:
+        with open(BANNED_IPS_FILE) as fh:
+            banned = {line.strip() for line in fh if line.strip()}
+    except FileNotFoundError:
+        return False
+    return ip in banned
 
 
 def is_malicious(req):
-    ua = req.headers.get('User-Agent', '').lower()
-    return 'curl' in ua or 'python-requests' in ua
+    if is_ip_banned(request.remote_addr):
+        return True
+    ua = req.headers.get("User-Agent", "").lower()
+    return "curl" in ua or "python-requests" in ua
 
 
 @app.route('/', defaults={'path': ''})


### PR DESCRIPTION
## Summary
- route requests from fail2ban-banned IPs to The Annoying Site
- share banned IP list between fail2ban and gateway
- add basic fail2ban action and jail configuration

## Testing
- `python -m py_compile gateway/app.py`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68b50fd7b374832794f93a7a44071e43