### PR TITLE
Add honeyd honeypot and configurable command-not-found handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DOMAIN=localhost
+CMD_NOT_FOUND_ACTION=echo "Command not found"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY app /app
+# Custom handler for missing commands
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 # Install Node.js and WebTorrent CLI
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
     npm install -g webtorrent-cli && \

--- a/annoyingsite/Dockerfile
+++ b/annoyingsite/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
-RUN apk add --no-cache git \
+RUN apk add --no-cache git bash \
     && git clone https://github.com/feross/TheAnnoyingSite.com /app
 WORKDIR /app
 RUN npm install
+# Custom handler for missing commands
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 EXPOSE 4000
 CMD ["npm", "start"]

--- a/blacklist/Dockerfile
+++ b/blacklist/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY requirements.txt /app
 RUN pip install --no-cache-dir -r requirements.txt
+# Custom handler for missing commands
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 COPY app.py /app
 EXPOSE 5001
 CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "80"
     volumes:
       - ./app:/app
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     depends_on:
       - blacklist
   blacklist:
@@ -14,11 +16,14 @@ services:
       - ./app/db:/db
     expose:
       - "5001"
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
   sanitizer:
     build: ./sanitizer
     environment:
       - UPSTREAM_URL=http://web:80
       - SANITIZER_CONFIG=/etc/gatekeeper/config.yml
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - ./sanitizer/config.example.yml:/etc/gatekeeper/config.yml:ro
     expose:
@@ -31,6 +36,7 @@ services:
       - "8080"
     environment:
       - API_WHITELIST_IP=0.0.0.0/0
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - bw-data:/var/lib/bunkerweb
     command: >
@@ -56,6 +62,7 @@ services:
       - CORAZA_API=http://bw-coraza:8080
       - USE_CLAMAV=yes
       - CLAMAV_HOST=clamav
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - bw-data:/data
     depends_on:
@@ -69,6 +76,7 @@ services:
       - "8000:80"
     environment:
       - BUNKERWEB_URL=http://bunkerweb:8080
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - bw-data:/var/lib/bunkerweb
     depends_on:
@@ -77,6 +85,8 @@ services:
     build: ./annoyingsite
     expose:
       - "4000"
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
   gateway:
     build: ./gateway
     ports:
@@ -85,6 +95,7 @@ services:
       - BUNKER_URL=http://bunkerweb:8080
       - ANNOY_URL=http://annoyingsite:4000
       - BANNED_IPS_FILE=/banned/banned_ips.list
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - ./banned:/banned
     depends_on:
@@ -97,16 +108,28 @@ services:
       - ./banned:/banned
     depends_on:
       - gateway
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
   clamav:
     image: clamav/clamav:1.4
     volumes:
       - ./clamav-data:/var/lib/clamav
     networks:
       - bw-plugins
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
   bw-coraza:
     image: bunkerity/bunkerweb-coraza:latest
     networks:
       - bw-plugins
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
+
+  honeypot:
+    build: ./honeypot
+    network_mode: host
+    environment:
+      - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
 
 volumes:
   bw-data:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+# Custom handler for missing commands
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 COPY app.py .
 EXPOSE 80
 CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stable-slim
+
+RUN apt-get update && apt-get install -y honeyd iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY honeyd.conf /etc/honeyd/honeyd.conf
+COPY fakeweb.sh /usr/local/bin/fakeweb.sh
+RUN chmod +x /usr/local/bin/fakeweb.sh
+
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+
+CMD ["honeyd", "-d", "-f", "/etc/honeyd/honeyd.conf"]

--- a/honeypot/fakeweb.sh
+++ b/honeypot/fakeweb.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Simple fake HTTP response for honeypot
+read request
+printf 'HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello World!'

--- a/honeypot/honeyd.conf
+++ b/honeypot/honeyd.conf
@@ -1,0 +1,3 @@
+create default
+add default tcp 1-21,23-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
+bind 0.0.0.0 default

--- a/sanitizer/Dockerfile
+++ b/sanitizer/Dockerfile
@@ -10,6 +10,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py ./app.py
 COPY config.example.yml /etc/gatekeeper/config.yml
 
+# Custom handler for missing commands
+RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+
 ENV UPSTREAM_URL=http://yourapp:8000
 ENV SANITIZER_CONFIG=/etc/gatekeeper/config.yml
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Add honeyd container that serves a fake HTTP response on all ports except 80 and 22
- Allow configuring a custom `command_not_found_handle` via `CMD_NOT_FOUND_ACTION` and propagate it to all containers

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5150787248327a213f75bb631b51a