### PR TITLE
Install honeyd from archived packages

### DIFF
--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -1,6 +1,17 @@
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install -y honeyd iproute2 \
+# honeyd was removed from modern Debian/Ubuntu repositories, so we grab
+# archived packages and install them manually. libevent-1.4 and
+# libreadline6 are required runtime dependencies that are also no longer
+# available in current repos.
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 wget \
+    && wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/libe/libevent/libevent-1.4-2_1.4.13-stable-1_amd64.deb \
+    https://old-releases.ubuntu.com/ubuntu/pool/main/r/readline6/libreadline6_6.0-5_amd64.deb \
+    https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd-common_1.5c-10ubuntu1_all.deb \
+    https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd_1.5c-10ubuntu1_amd64.deb \
+    && apt-get install -y --no-install-recommends ./libevent-1.4-2_1.4.13-stable-1_amd64.deb ./libreadline6_6.0-5_amd64.deb \
+    && dpkg -i --force-depends honeyd-common_1.5c-10ubuntu1_all.deb honeyd_1.5c-10ubuntu1_amd64.deb \
+    && rm -f *.deb \
     && rm -rf /var/lib/apt/lists/*
 
 COPY honeyd.conf /etc/honeyd/honeyd.conf


### PR DESCRIPTION
## Summary
- Install honeyd by fetching archived .deb packages and required libraries
- Add iproute2 and wget to honeypot image

## Testing
- `docker build -t test-honeyd honeypot` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b516670054832791168c53aa362205