### PR TITLE
Set noninteractive debconf frontend for honeypot build

### DIFF
--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -1,4 +1,8 @@
+# Use a non-interactive frontend for all package installation to avoid
+# prompts during build which previously caused failures.
 FROM debian:stable-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 # honeyd was removed from modern Debian/Ubuntu repositories, so we grab
 # archived packages and install them manually. libevent-1.4 and


### PR DESCRIPTION
## Summary
- avoid interactive debconf prompts while installing archived honeyd packages

## Testing
- `docker build honeypot -t honeypot-test` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b518e0feec832791166bb398ae5c9c