### PR TITLE
fix: add libncurses5 dependency for honeypot

### DIFF
--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -7,14 +7,19 @@ ARG DEBIAN_FRONTEND=noninteractive
 # honeyd was removed from modern Debian/Ubuntu repositories, so we grab
 # archived packages and install them manually. libevent-1.4 and
 # libreadline6 are required runtime dependencies that are also no longer
-# available in current repos.
+# available in current repos. libreadline6 further depends on the now
+# retired libncurses5, so we fetch that package as well.
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iproute2 wget \
     && update-ca-certificates \
     && wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/libe/libevent/libevent-1.4-2_1.4.13-stable-1_amd64.deb \
     https://old-releases.ubuntu.com/ubuntu/pool/main/r/readline6/libreadline6_6.0-5_amd64.deb \
+    https://old-releases.ubuntu.com/ubuntu/pool/main/n/ncurses/libncurses5_5.7+20090803-2ubuntu3_amd64.deb \
     https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd-common_1.5c-10ubuntu1_all.deb \
     https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd_1.5c-10ubuntu1_amd64.deb \
-    && apt-get install -y --no-install-recommends ./libevent-1.4-2_1.4.13-stable-1_amd64.deb ./libreadline6_6.0-5_amd64.deb \
+    && apt-get install -y --no-install-recommends \
+       ./libevent-1.4-2_1.4.13-stable-1_amd64.deb \
+       ./libncurses5_5.7+20090803-2ubuntu3_amd64.deb \
+       ./libreadline6_6.0-5_amd64.deb \
     && dpkg -i --force-depends honeyd-common_1.5c-10ubuntu1_all.deb honeyd_1.5c-10ubuntu1_amd64.deb \
     && rm -f *.deb \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- include libncurses5 in honeypot Docker build
- document requirement in Dockerfile comments

## Testing
- `apt-get install -y docker.io >/tmp/docker-install.log && tail -n 20 /tmp/docker-install.log`
- `docker build -t dojonews-honeypot honeypot >/tmp/build.log && tail -n 20 /tmp/build.log` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_e_68b51b0e01a48327b5caa460ae93cdc2