### PR TITLE
Fix static assets path

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -148,8 +148,9 @@ Log.info("Starting...")
 app = Flask(
     import_name=Settings.APP_NAME,
     root_path=Settings.APP_ROOT_PATH,
-    template_folder="app/templates",
-    static_folder="app/static",
+    template_folder=os.path.join(Settings.APP_ROOT_PATH, "app", "templates"),
+    static_folder=os.path.join(Settings.APP_ROOT_PATH, "app", "static"),
+    static_url_path="/static",
 )
 
 


### PR DESCRIPTION
## Summary
- Ensure Flask uses absolute paths for template and static directories
- Explicitly configure `/static` URL for serving JS/CSS assets

## Testing
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('app')
import app as app_module
app = app_module.app
with app.test_client() as c:
    r = c.get('/static/js/debug.js')
    print('status', r.status_code)
    print('length', len(r.data))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b51ec7d6e4832784865dc32dc0fd91