### PR TITLE
Add gateway logging and default ban list file

### DIFF
--- a/banned/banned_ips.list
+++ b/banned/banned_ips.list
@@ -1,0 +1,1 @@
+# Add banned IPs below

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -5,5 +5,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 COPY app.py .
+RUN mkdir -p /banned && touch /banned/banned_ips.list
 EXPOSE 80
 CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]


### PR DESCRIPTION
## Summary
- add detailed logging in gateway for IP bans, request info, and fallback decisions
- ensure `/banned/banned_ips.list` exists via Dockerfile and default file

## Testing
- `flake8 gateway/app.py`
- `python -m py_compile gateway/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b52487fd6c832791225427090d30a8