### PR TITLE
Add logging entrypoints for all custom containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /app
 COPY app /app
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+# Logging configuration
+ENV SERVICE_NAME=web
+ENV LOG_FILE=/logs/web.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 # Install Node.js and WebTorrent CLI
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
     npm install -g webtorrent-cli && \
@@ -12,4 +17,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && \
 RUN (pip install --no-cache-dir uv && uv pip install --system -r requirements.txt) || \
     pip install --no-cache-dir -r requirements.txt
 EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "app.py"]

--- a/annoyingsite/Dockerfile
+++ b/annoyingsite/Dockerfile
@@ -5,5 +5,10 @@ WORKDIR /app
 RUN npm install
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+ENV SERVICE_NAME=annoyingsite
+ENV LOG_FILE=/logs/annoyingsite.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 4000
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["npm", "start"]

--- a/annoyingsite/entrypoint.sh
+++ b/annoyingsite/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"

--- a/blacklist/Dockerfile
+++ b/blacklist/Dockerfile
@@ -4,6 +4,11 @@ COPY requirements.txt /app
 RUN pip install --no-cache-dir -r requirements.txt
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+ENV SERVICE_NAME=blacklist
+ENV LOG_FILE=/logs/blacklist.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 COPY app.py /app
 EXPOSE 5001
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "app.py"]

--- a/blacklist/entrypoint.sh
+++ b/blacklist/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,7 +4,12 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+ENV SERVICE_NAME=gateway
+ENV LOG_FILE=/logs/gateway.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 COPY app.py .
 RUN mkdir -p /banned && touch /banned/banned_ips.list
 EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -29,5 +29,9 @@ COPY fakeweb.sh /usr/local/bin/fakeweb.sh
 RUN chmod +x /usr/local/bin/fakeweb.sh
 
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
-
+ENV SERVICE_NAME=honeypot
+ENV LOG_FILE=/logs/honeypot.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["honeyd", "-d", "-f", "/etc/honeyd/honeyd.conf"]

--- a/honeypot/entrypoint.sh
+++ b/honeypot/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"

--- a/sanitizer/Dockerfile
+++ b/sanitizer/Dockerfile
@@ -12,9 +12,13 @@ COPY config.example.yml /etc/gatekeeper/config.yml
 
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
+ENV SERVICE_NAME=sanitizer
+ENV LOG_FILE=/logs/sanitizer.log
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENV UPSTREAM_URL=http://yourapp:8000
 ENV SANITIZER_CONFIG=/etc/gatekeeper/config.yml
 EXPOSE 8080
-
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/sanitizer/entrypoint.sh
+++ b/sanitizer/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+: "${LOG_FILE:=/logs/container.log}"
+: "${SERVICE_NAME:=container}"
+mkdir -p "$(dirname "$LOG_FILE")"
+{
+  echo "==== $(date -u '+%Y-%m-%d %H:%M:%S') UTC ===="
+  echo "Starting $SERVICE_NAME container"
+  echo "Command: $*"
+  echo "Environment:"
+  env
+  echo "==============================="
+} >> "$LOG_FILE"
+exec "$@"


### PR DESCRIPTION
## Summary
- add reusable entrypoint script that logs startup info and environment
- enable comprehensive logging across web, blacklist, sanitizer, gateway, annoyingsite, and honeypot images

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b5bfec10a48327a140afa4d5bb3387