### PR TITLE
Fix proxy static handling and service configs

### DIFF
--- a/fail2ban/fail2ban.conf
+++ b/fail2ban/fail2ban.conf
@@ -1,0 +1,5 @@
+[Definition]
+loglevel = INFO
+logtarget = /logs/fail2ban.log
+dbfile = /var/lib/fail2ban/fail2ban.sqlite3
+dbpurgeage = 86400

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -2,6 +2,6 @@
 enabled = true
 port = http,https
 filter = annoyingsite
-logpath = /var/log/gateway/access.log
+logpath = /logs/gateway.log
 maxretry = 1
 action = annoyingsite[file=/banned/banned_ips.list]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -12,13 +12,14 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # The gateway acts purely as a proxy and should not attempt to serve static
-# files itself.  Previously ``Flask`` was initialised with a ``static_folder``
-# which caused requests to ``/static`` to be handled locally and never reach the
-# upstream services, leaving no trace in the logs.  By omitting the static
-# configuration all requests, including those for missing static assets, are
-# routed through the proxy logic below and therefore recorded in the logs of
-# every container in the chain.
-app = Flask(__name__)
+# files itself.  Flask will automatically serve files from a ``static``
+# directory unless this behaviour is explicitly disabled.  When that happens
+# requests to paths such as ``/static/js/app.js`` never hit our proxy logic and
+# are instead handled (and potentially 404'd) by Flask itself, meaning they are
+# not forwarded to upstream services and are missing from the logs.  By
+# constructing the application with ``static_folder=None`` we ensure *all*
+# requests pass through the proxy code below.
+app = Flask(__name__, static_folder=None)
 
 BUNKER_URL = os.environ.get("BUNKER_URL", "http://bunkerweb:8080")
 ANNOY_URL = os.environ.get("ANNOY_URL", "http://annoyingsite:4000")

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # libreadline6 are required runtime dependencies that are also no longer
 # available in current repos. libreadline6 further depends on the now
 # retired libncurses5, so we fetch that package as well.
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iproute2 wget adduser libpcap0.8 \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iproute2 wget adduser libpcap0.8 libdumbnet1 \
     && update-ca-certificates \
     && wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/libe/libevent/libevent-1.4-2_1.4.13-stable-1_amd64.deb \
     https://old-releases.ubuntu.com/ubuntu/pool/main/r/readline6/libreadline6_6.0-5_amd64.deb \


### PR DESCRIPTION
## Summary
- Proxy all /static requests by disabling Flask's built-in static handler in gateway
- Install libdumbnet in honeypot image to satisfy honeyd dependency
- Configure fail2ban with proper log paths and base configuration

## Testing
- `python -m py_compile gateway/app.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c5629ac08327b2c6ec9e92fca140