### PR TITLE
Redirect 404s to the annoyingsite

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -68,8 +68,9 @@ def is_malicious(req):
     methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
 )
 def proxy(path):
-    def forward(target_url):
-        url = f"{target_url}/{path}"
+    def forward(target_url, override_path=None):
+        url_path = path if override_path is None else override_path
+        url = f"{target_url}/{url_path}"
         return requests.request(
             method=request.method,
             url=url,
@@ -87,7 +88,7 @@ def proxy(path):
         logger.warning(
             "Received 404 from %s, falling back to annoyingsite", target
         )
-        resp = forward(ANNOY_URL)
+        resp = forward(ANNOY_URL, "")
 
     excluded = {
         'content-encoding',


### PR DESCRIPTION
## Summary
- Allow gateway proxy to override forward path
- Route 404 responses to annoyingsite root so the script runs

## Testing
- `python -m py_compile gateway/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c75210cc83279c970184987a2d6d