### PR TITLE
Fallback to annoyingsite for gateway errors

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -82,11 +82,15 @@ def proxy(path):
 
     target = ANNOY_URL if is_malicious(request) else BUNKER_URL
     logger.info("Forwarding path '%s' to %s", path, target)
-    resp = forward(target)
+    try:
+        resp = forward(target)
+    except requests.RequestException as exc:
+        logger.warning("Error forwarding to %s: %s", target, exc)
+        resp = forward(ANNOY_URL, "")
 
-    if resp.status_code == 404 and target != ANNOY_URL:
+    if resp.status_code >= 400 and target != ANNOY_URL:
         logger.warning(
-            "Received 404 from %s, falling back to annoyingsite", target
+            "Received %s from %s, falling back to annoyingsite", resp.status_code, target
         )
         resp = forward(ANNOY_URL, "")
 


### PR DESCRIPTION
## Summary
- ensure gateway forwards to annoyingsite when upstream errors occur
- log and handle proxy errors instead of returning 500

## Testing
- `pytest`
- `python -m py_compile gateway/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc5923708327a7de908dae0c49ef