### PR TITLE
Fix honeyd configuration port directives

### DIFF
--- a/honeypot/honeyd.conf
+++ b/honeypot/honeyd.conf
@@ -1,7 +1,7 @@
 create default
 # Spoof every port except 80 with our fake service
 # TCP ports 1-79 and 81-65535
-add default tcp 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
+add default tcp port 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
 # UDP ports 1-79 and 81-65535
-add default udp 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
+add default udp port 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
 bind 0.0.0.0 default


### PR DESCRIPTION
## Summary
- correct honeyd `add` directives to specify port ranges for TCP and UDP

## Testing
- `sh -n honeypot/fakeweb.sh`
- `sh -n honeypot/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5c6ccf08327979476f7d12c1b20