### PR TITLE
Replace honeyd with portspoof

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
       - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - ./logs:/logs
-    command: /bin/sh -c "honeyd -d -f /etc/honeyd/honeyd.conf >> /logs/honeypot.log 2>&1"
+    command: /bin/sh -c "portspoof -D -p 4444 >> /logs/honeypot.log 2>&1"
 
 volumes:
   bw-data:

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -4,29 +4,18 @@ FROM debian:stable-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# honeyd was removed from modern Debian/Ubuntu repositories, so we grab
-# archived packages and install them manually. libevent-1.4 and
-# libreadline6 are required runtime dependencies that are also no longer
-# available in current repos. libreadline6 further depends on the now
-# retired libncurses5, so we fetch that package as well.
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iproute2 wget adduser libpcap0.8 libdumbnet1 \
+# Install dependencies and build portspoof from source
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates iproute2 iptables git build-essential \
     && update-ca-certificates \
-    && wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/libe/libevent/libevent-1.4-2_1.4.13-stable-1_amd64.deb \
-    https://old-releases.ubuntu.com/ubuntu/pool/main/r/readline6/libreadline6_6.0-5_amd64.deb \
-    https://old-releases.ubuntu.com/ubuntu/pool/main/n/ncurses/libncurses5_5.7+20090803-2ubuntu3_amd64.deb \
-    https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd-common_1.5c-10ubuntu1_all.deb \
-    https://old-releases.ubuntu.com/ubuntu/pool/universe/h/honeyd/honeyd_1.5c-10ubuntu1_amd64.deb \
-    && apt-get install -y --no-install-recommends \
-       ./libevent-1.4-2_1.4.13-stable-1_amd64.deb \
-       ./libncurses5_5.7+20090803-2ubuntu3_amd64.deb \
-       ./libreadline6_6.0-5_amd64.deb \
-    && dpkg -i --force-depends honeyd-common_1.5c-10ubuntu1_all.deb honeyd_1.5c-10ubuntu1_amd64.deb \
-    && rm -f *.deb \
+    && git clone https://github.com/drk1wi/portspoof.git /opt/portspoof \
+    && cd /opt/portspoof \
+    && ./configure \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /opt/portspoof \
     && rm -rf /var/lib/apt/lists/*
-
-COPY honeyd.conf /etc/honeyd/honeyd.conf
-COPY fakeweb.sh /usr/local/bin/fakeweb.sh
-RUN chmod +x /usr/local/bin/fakeweb.sh
 
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 ENV SERVICE_NAME=honeypot
@@ -34,4 +23,4 @@ ENV LOG_FILE=/logs/honeypot.log
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["honeyd", "-d", "-f", "/etc/honeyd/honeyd.conf"]
+CMD ["portspoof", "-D", "-p", "4444"]

--- a/honeypot/build.sh
+++ b/honeypot/build.sh
@@ -7,7 +7,7 @@ DIR="$(dirname "$0")"
 
 docker build -t "$IMAGE" "$DIR"
 # Use host networking so every host port is forwarded into the container
-# Capabilities allow honeyd to bind low ports and craft packets
+# Capabilities allow portspoof to manage iptables and bind low ports
 if ! docker ps --format '{{.Names}}' | grep -q "^${IMAGE}$"; then
   docker run -d --name "$IMAGE" --network host \
     --cap-add=NET_ADMIN --cap-add=NET_RAW "$IMAGE"

--- a/honeypot/entrypoint.sh
+++ b/honeypot/entrypoint.sh
@@ -11,4 +11,20 @@ mkdir -p "$(dirname "$LOG_FILE")"
   env
   echo "==============================="
 } >> "$LOG_FILE"
+# Redirect all ports except 22 and 80 to portspoof (TCP and UDP)
+iptables -t nat -N PREPORTSPOOF 2>/dev/null || true
+iptables -t nat -F PREPORTSPOOF
+iptables -t nat -N PORTSPOOF 2>/dev/null || true
+iptables -t nat -F PORTSPOOF
+iptables -t nat -A PORTSPOOF -p tcp -j REDIRECT --to-ports 4444
+iptables -t nat -A PORTSPOOF -p udp -j REDIRECT --to-ports 4444
+iptables -t nat -A PREPORTSPOOF -p tcp --dport 22 -j RETURN
+iptables -t nat -A PREPORTSPOOF -p udp --dport 22 -j RETURN
+iptables -t nat -A PREPORTSPOOF -p tcp --dport 80 -j RETURN
+iptables -t nat -A PREPORTSPOOF -p udp --dport 80 -j RETURN
+iptables -t nat -A PREPORTSPOOF -p tcp -j PORTSPOOF
+iptables -t nat -A PREPORTSPOOF -p udp -j PORTSPOOF
+iptables -t nat -D PREROUTING -j PREPORTSPOOF 2>/dev/null || true
+iptables -t nat -A PREROUTING -j PREPORTSPOOF
+
 exec "$@"

--- a/honeypot/fakeweb.sh
+++ b/honeypot/fakeweb.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Simple fake HTTP response for honeypot
-# Each connection gets its own environment with port information.
-read request
-PORT="${HONEYD_LOCAL_PORT:-$HONEYD_PORT}"
-MESSAGE="Hello from port ${PORT}"
-printf 'HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s' "${#MESSAGE}" "$MESSAGE"

--- a/honeypot/honeyd.conf
+++ b/honeypot/honeyd.conf
@@ -1,7 +1,0 @@
-create default
-# Spoof every port except 80 with our fake service
-# TCP ports 1-79 and 81-65535
-add default tcp port 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
-# UDP ports 1-79 and 81-65535
-add default udp port 1-79,81-65535 "sh /usr/local/bin/fakeweb.sh"
-bind 0.0.0.0 default


### PR DESCRIPTION
## Summary
- build portspoof in honeypot image and run it instead of honeyd
- redirect all ports except 22 and 80 to portspoof using iptables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7a4daf08327bb6046a3f8753887