### PR TITLE
Add host port forwarding helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ based on a simple user‑agent check. BunkerWeb's management UI is still
 available on port `8000`. The `DOMAIN` value defines which Host header
 the stack accepts.
 
+If you need to expose a running container on all host ports (except SSH on
+port 22 and HTTP on port 80), use the `host_port_forward.sh` script on the
+host:
+
+```bash
+sudo ./host_port_forward.sh <container_name>
+```
+
+
 ### Blockchain
 
 User accounts, posts, comments, tipping, sponsor slots and media magnets are now handled by dedicated contracts under [`contracts/`](contracts/). Each contract is owned by the sysop who deployed it, while public methods let authors create posts or comments and fans send tips. All smart-contract interactions are performed in the browser via `ethers.js`, keeping the Flask backend free of blockchain dependencies.

--- a/host_port_forward.sh
+++ b/host_port_forward.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Forward all host ports except 22 and 80 to a Docker container.
+# Usage: ./host_port_forward.sh <container_name>
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root" >&2
+  exit 1
+fi
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <container_name>" >&2
+  exit 1
+fi
+
+CONTAINER_NAME="$1"
+
+# Resolve container IP address
+CONTAINER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CONTAINER_NAME" 2>/dev/null)
+
+if [ -z "$CONTAINER_IP" ]; then
+  echo "Could not resolve IP for container '$CONTAINER_NAME'" >&2
+  exit 1
+fi
+
+# Forward all TCP ports except 22 and 80 to the container
+iptables -t nat -A PREROUTING -p tcp -m multiport ! --dports 22,80 -j DNAT --to-destination "$CONTAINER_IP"
+iptables -t nat -A POSTROUTING -p tcp -d "$CONTAINER_IP" -m multiport ! --dports 22,80 -j MASQUERADE
+
+echo "Forwarding all host TCP ports except 22 and 80 to $CONTAINER_NAME ($CONTAINER_IP)"


### PR DESCRIPTION
## Summary
- add `host_port_forward.sh` for forwarding host ports to running containers via iptables
- document how to use the helper in Docker Compose instructions

## Testing
- `sh -n host_port_forward.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e9a93de4832799c0e1c9d4370b6e