### PR TITLE
Ensure DNS resolution during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV SERVICE_NAME=web
 ENV LOG_FILE=/logs/web.log
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+# Configure DNS to ensure external resources resolve during build
+RUN printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > /etc/resolv.conf
 # Install Node.js and WebTorrent CLI
 # Use the official pre-built Node.js binaries instead of Debian packages to
 # avoid hitting the Debian mirrors during build.  The image used in tests runs


### PR DESCRIPTION
## Summary
- configure container to use public DNS servers before downloading Node.js

## Testing
- `pytest`
- `docker build -t dojonews-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee468f5c8327a9574a1f38ecc342