### PR TITLE
Configure DNS at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV SERVICE_NAME=web
 ENV LOG_FILE=/logs/web.log
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-# Configure DNS to ensure external resources resolve during build
-RUN printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > /etc/resolv.conf
+# DNS servers are configured at runtime via docker-compose
 # Install Node.js and WebTorrent CLI
 # Use the official pre-built Node.js binaries instead of Debian packages to
 # avoid hitting the Debian mirrors during build.  The image used in tests runs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - ./logs:/logs
     environment:
       - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
     command: /bin/sh -c "python app.py >> /logs/web.log 2>&1"
     depends_on:
       - blacklist


### PR DESCRIPTION
## Summary
- Remove build-time attempt to overwrite `/etc/resolv.conf`.
- Define DNS servers in `docker-compose.yml` so containers resolve names correctly at runtime.

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68b5f0901bf48327a155edf049a174f6