### PR TITLE
fix: restore Node setup with build-time DNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV SERVICE_NAME=web
 ENV LOG_FILE=/logs/web.log
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+# Configure DNS servers for build-time operations
+RUN echo -e "nameserver 8.8.8.8\nnameserver 1.1.1.1" > /etc/resolv.conf
 # DNS servers are configured at runtime via docker-compose
 # Install Node.js and WebTorrent CLI
 # Use the official pre-built Node.js binaries instead of Debian packages to


### PR DESCRIPTION
## Summary
- configure DNS inside Dockerfile to allow Node.js download during build
- reinstall Node.js and webtorrent CLI for full functionality

## Testing
- `pytest`
- `docker build .` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f4072b108327956f0b79c884ea15