### PR TITLE
Keep honeypot container running and auto-restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,11 +156,13 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
+    restart: always
     environment:
       - CMD_NOT_FOUND_ACTION=${CMD_NOT_FOUND_ACTION}
     volumes:
       - ./logs:/logs
-    command: /bin/sh -c "portspoof -D -p 4444 >> /logs/honeypot.log 2>&1"
+    # Run portspoof in the foreground so Docker can monitor it and restart if needed
+    command: /bin/sh -c "portspoof -p 4444 >> /logs/honeypot.log 2>&1"
 
 volumes:
   bw-data:

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -23,4 +23,5 @@ ENV LOG_FILE=/logs/honeypot.log
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["portspoof", "-D", "-p", "4444"]
+# Run portspoof in the foreground so the container stays alive
+CMD ["portspoof", "-p", "4444"]


### PR DESCRIPTION
## Summary
- run portspoof in the foreground so the honeypot container doesn't exit immediately
- add Docker restart policy for the honeypot service

## Testing
- `bash -n honeypot/entrypoint.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b618d16ea48327b81f3671f069e71c