### PR TITLE
Automate honeypot startup at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,26 +46,27 @@ Visit `http://localhost:1283` in your browser.
 
 ### Docker Compose
 
-Run the full stack with Docker:
+The stack can now be launched automatically at boot. Install the supplied
+systemd service to build the images, start the containers and forward host
+ports to the honeypot container:
 
 ```bash
 # edit DOMAIN in .env if you want BunkerWeb to answer on a custom domain
-docker compose up --build
+sudo cp honeypot_boot.sh /usr/local/bin/
+sudo cp dojonews-honeypot.service /etc/systemd/system/
+sudo systemctl enable --now dojonews-honeypot.service
 ```
+
+The unit waits for the `dojonews-honeypot` container to come online before
+invoking `host_port_forward.sh`, forwarding every host TCP port except 22 and
+80 to the container. Once enabled, the honeypot starts automatically whenever
+the server boots.
 
 The `gateway` service now listens on port `80` and decides whether to send
 traffic to BunkerWeb or to an [annoying honeypot](https://github.com/feross/TheAnnoyingSite.com)
 based on a simple user‑agent check. BunkerWeb's management UI is still
-available on port `8000`. The `DOMAIN` value defines which Host header
-the stack accepts.
-
-If you need to expose a running container on all host ports (except SSH on
-port 22 and HTTP on port 80), use the `host_port_forward.sh` script on the
-host:
-
-```bash
-sudo ./host_port_forward.sh <container_name>
-```
+available on port `8000`. The `DOMAIN` value defines which Host header the
+stack accepts.
 
 
 ### Blockchain

--- a/dojonews-honeypot.service
+++ b/dojonews-honeypot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=DojoNews Honeypot Stack
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Adjust the path below to the repository location
+WorkingDirectory=/workspace/DojoNews
+ExecStart=/bin/sh /workspace/DojoNews/honeypot_boot.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/honeypot_boot.sh
+++ b/honeypot_boot.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Start DojoNews stack and forward ports to the honeypot container
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root" >&2
+  exit 1
+fi
+
+CONTAINER_NAME="dojonews-honeypot"
+
+# Build and start the Docker Compose stack
+docker compose up -d --build
+
+# Wait for the honeypot container to be running
+until [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]; do
+  sleep 1
+done
+
+# Forward host ports (except 22 and 80) to the container
+"$(dirname "$0")/host_port_forward.sh" "$CONTAINER_NAME"


### PR DESCRIPTION
## Summary
- Add `honeypot_boot.sh` script to build and run the Compose stack and forward ports to the `dojonews-honeypot` container.
- Provide `dojonews-honeypot.service` systemd unit so the stack starts automatically on boot.
- Update documentation to describe using the new service instead of manual `docker compose` and port forwarding commands.

## Testing
- `sh -n honeypot_boot.sh`
- `sh -n host_port_forward.sh`
- `shellcheck honeypot_boot.sh` *(fails: command not found)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61c3e2d188327876884b9a39aa90e