### PR TITLE
Switch to strm dnsmasq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   dnsproxy:
-    image: andyshinn/dnsmasq:2.85
+    image: strm/dnsmasq:latest
     cap_add:
       - NET_ADMIN
     command: ["-k", "--log-facility=-", "--server=213.186.33.99"]


### PR DESCRIPTION
## Summary
- Use strm/dnsmasq container for dnsproxy service

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68b63472a9bc8327bac4a9cd7afd8b08