### PR TITLE
Expose dnsmasq to containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - NET_ADMIN
     command: ["-k", "--log-facility=-", "--server=213.186.33.99"]
     ports:
-      - "127.0.0.1:53:53/udp"
+      - "53:53/udp"
   web:
     build: .
     expose:


### PR DESCRIPTION
## Summary
- Expose dnsproxy on all interfaces so other services reach it via host DNS

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b635f178088327807d5e0ad8e9845b