### PR TITLE
Switch service Dockerfiles to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Simple Flask app container
+# Note: Debian base is required because Node.js binaries needed below
+# depend on glibc, which is not available in Alpine.
 FROM python:3.10-slim
 WORKDIR /app
 COPY app /app

--- a/blacklist/Dockerfile
+++ b/blacklist/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-alpine
 WORKDIR /app
 COPY requirements.txt /app
 RUN pip install --no-cache-dir -r requirements.txt

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-alpine
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -1,12 +1,9 @@
 # Use a non-interactive frontend for all package installation to avoid
 # prompts during build which previously caused failures.
-FROM debian:stable-slim
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM alpine:3.20
 
 # Install dependencies and build portspoof from source
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates iproute2 iptables git build-essential \
+RUN apk add --no-cache ca-certificates iproute2 iptables git build-base \
     && update-ca-certificates \
     && git clone https://github.com/drk1wi/portspoof.git /opt/portspoof \
     && cd /opt/portspoof \
@@ -14,8 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && make \
     && make install \
     && cd / \
-    && rm -rf /opt/portspoof \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /opt/portspoof
 
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 ENV SERVICE_NAME=honeypot

--- a/sanitizer/Dockerfile
+++ b/sanitizer/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.11-slim
+FROM python:3.11-alpine
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /app
+RUN apk add --no-cache build-base libffi-dev && \
+    rm -rf /var/cache/apk/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- use Alpine Python images for sanitizer, blacklist, and gateway containers
- build honeypot on Alpine instead of Debian
- document why web service still relies on Debian base

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6391479a4832796aecf1f548c0b0c