### PR TITLE
Remove hardcoded proxy from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ PY
 ENV PATH="/usr/local/node/bin:${PATH}"
 RUN npm install -g webtorrent-cli
 # Install Python dependencies using uv if available, fall back to pip
-RUN (pip install --no-cache-dir --proxy http://5.79.73.131:13040 uv && \
-    uv pip install --system --proxy http://5.79.73.131:13040 -r requirements.txt) || \
-    pip install --no-cache-dir --proxy http://5.79.73.131:13040 -r requirements.txt
+RUN (pip install --no-cache-dir uv && \
+    uv pip install --system -r requirements.txt) || \
+    pip install --no-cache-dir -r requirements.txt
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "app.py"]

--- a/blacklist/Dockerfile
+++ b/blacklist/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine
 WORKDIR /app
 COPY requirements.txt /app
-RUN pip install --no-cache-dir --proxy http://5.79.73.131:13040 -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 ENV SERVICE_NAME=blacklist

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-alpine
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir --proxy http://5.79.73.131:13040 -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 # Custom handler for missing commands
 RUN echo 'command_not_found_handle() { eval "$CMD_NOT_FOUND_ACTION"; }' > /etc/profile.d/command_not_found.sh
 ENV SERVICE_NAME=gateway

--- a/sanitizer/Dockerfile
+++ b/sanitizer/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN apk add --no-cache build-base libffi-dev && \
     rm -rf /var/cache/apk/*
 COPY requirements.txt .
-RUN pip install --no-cache-dir --proxy http://5.79.73.131:13040 -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py ./app.py
 COPY config.example.yml /etc/gatekeeper/config.yml


### PR DESCRIPTION
## Summary
- remove hardcoded proxy option from root Dockerfile
- drop proxy usage from gateway, sanitizer, and blacklist service Dockerfiles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b65029b9308327bcf506ce78f4c3f4