### PR TITLE
fix: add linux headers for portspoof

### DIFF
--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -3,7 +3,8 @@
 FROM alpine:3.20
 
 # Install dependencies and build portspoof from source
-RUN apk add --no-cache ca-certificates iproute2 iptables git build-base \
+# linux-headers provides <linux/sockios.h> required by portspoof
+RUN apk add --no-cache ca-certificates iproute2 iptables git build-base linux-headers \
     && update-ca-certificates \
     && git clone https://github.com/drk1wi/portspoof.git /opt/portspoof \
     && cd /opt/portspoof \


### PR DESCRIPTION
## Summary
- include linux-headers package in honeypot Dockerfile to compile portspoof

## Testing
- `docker version` *(fails: Cannot connect to the Docker daemon)*
- `dockerd` *(fails: failed to start daemon: Error initializing network controller)*

------
https://chatgpt.com/codex/tasks/task_e_68b650c827888327bdc1c9c9bdd2e8c0