### PR TITLE
Limit honeypot iptables rules to external interface

### DIFF
--- a/honeypot/entrypoint.sh
+++ b/honeypot/entrypoint.sh
@@ -11,20 +11,27 @@ mkdir -p "$(dirname "$LOG_FILE")"
   env
   echo "==============================="
 } >> "$LOG_FILE"
-# Redirect all ports except 22 and 80 to portspoof (TCP and UDP)
+
+# Determine the external interface to avoid hijacking traffic from other
+# containers. Fallback to eth0 when detection fails.
+IFACE="$(ip route show default 2>/dev/null | awk '{print $5}' | head -n1)"
+IFACE="${IFACE:-eth0}"
+
+# Redirect all ports except 22 and 80 arriving on the external interface to
+# portspoof (TCP and UDP)
 iptables -t nat -N PREPORTSPOOF 2>/dev/null || true
 iptables -t nat -F PREPORTSPOOF
 iptables -t nat -N PORTSPOOF 2>/dev/null || true
 iptables -t nat -F PORTSPOOF
 iptables -t nat -A PORTSPOOF -p tcp -j REDIRECT --to-ports 4444
 iptables -t nat -A PORTSPOOF -p udp -j REDIRECT --to-ports 4444
-iptables -t nat -A PREPORTSPOOF -p tcp --dport 22 -j RETURN
-iptables -t nat -A PREPORTSPOOF -p udp --dport 22 -j RETURN
-iptables -t nat -A PREPORTSPOOF -p tcp --dport 80 -j RETURN
-iptables -t nat -A PREPORTSPOOF -p udp --dport 80 -j RETURN
-iptables -t nat -A PREPORTSPOOF -p tcp -j PORTSPOOF
-iptables -t nat -A PREPORTSPOOF -p udp -j PORTSPOOF
-iptables -t nat -D PREROUTING -j PREPORTSPOOF 2>/dev/null || true
-iptables -t nat -A PREROUTING -j PREPORTSPOOF
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p tcp --dport 22 -j RETURN
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p udp --dport 22 -j RETURN
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p tcp --dport 80 -j RETURN
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p udp --dport 80 -j RETURN
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p tcp -j PORTSPOOF
+iptables -t nat -A PREPORTSPOOF -i "$IFACE" -p udp -j PORTSPOOF
+iptables -t nat -D PREROUTING -i "$IFACE" -j PREPORTSPOOF 2>/dev/null || true
+iptables -t nat -A PREROUTING -i "$IFACE" -j PREPORTSPOOF
 
 exec "$@"


### PR DESCRIPTION
## Summary
- Detect host's default network interface in honeypot entrypoint
- Apply iptables portspoof rules only on that interface to avoid hijacking other containers' traffic

## Testing
- `shellcheck honeypot/entrypoint.sh`
- `sh -n honeypot/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b66828f2508327b3285133bcf33bd6