### PR TITLE
Minify inline CSS and JavaScript

### DIFF
--- a/spamsites/annoyingsite/korsse.neocities.org/spg/mspaint.html
+++ b/spamsites/annoyingsite/korsse.neocities.org/spg/mspaint.html
@@ -2,14 +2,7 @@
 <head>
 <link rel="shortcut icon" href="../favicon.ico"/> <meta charset="UTF-8"> <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Korsse|MS Paint guide</title> <link href="mspaint.css" rel="stylesheet" type="text/css" media="all">
-<style>
-    body {background-color:blue; color: white}    
-    .return{ width:710px;margin-left:28% ;margin-right: ;}
-/* NOT VISITED */ a:link {color:slateblue;}
-/* VISITED */ a:visited {color:darkslategray;}
-/* HOVERING */ a:hover {color:slategray; text-decoration:underline;}
-/* CLICK */ a:active {color:darkslateblue; text-decoration:underline;}   
-</style>
+<style>body{background-color:blue;color:white}.return{width:710px;margin-left:28%;margin-right:}a:link{color:slateblue}a:visited{color:darkslategray}a:hover{color:slategray;text-decoration:underline}a:active{color:darkslateblue;text-decoration:underline}</style>
 </head>
 <body>
     <h1>MS Paint Guide</h1>
@@ -154,37 +147,4 @@ With much sorrow and a heavy heart, I regret to inform you that it will not be t
 </div>
 </div>    
     
-</body>
-    <script>
-    // Get the modal
-var modal = document.getElementById("myModal");
-
-// Get the button that opens the modal
-var btn = document.getElementById("myBtn");
-
-// Get the <span> element that closes the modal
-var button = document.getElementsByClassName("decor")[0];
-
-// Get the <span> element that closes the modal
-var button = document.getElementsByClassName("close")[0];
-
-
-// When the user clicks the button, open the modal 
-btn.onclick = function() {
-  modal.style.display = "block";
-}
-
-// When the user clicks on <span> (x), close the modal
-button.onclick = function() {
-  modal.style.display = "none";
-}
-
-// When the user clicks on <span> (x), close the modal
-button.onclick = function() {
-  modal.style.display = "none";
-}
-
-
-    
-    </script>
-</html>
+</body><script>var modal=document.getElementById("myModal"),btn=document.getElementById("myBtn"),button=document.getElementsByClassName("decor")[0];button=document.getElementsByClassName("close")[0];btn.onclick=function(){modal.style.display="block"};button.onclick=function(){modal.style.display="none"};button.onclick=function(){modal.style.display="none"};</script></html>


### PR DESCRIPTION
## Summary
- Minify inline CSS rules in `mspaint.html`
- Condense JavaScript modal logic into a single line

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest` *(passes: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68ba25eb4bec8327978197012d3e8737