### PR TITLE
Minify inline CSS and scripts for spam site sample

### DIFF
--- a/spamsites/annoyingsite/angiepolis.neocities.org/index.html
+++ b/spamsites/annoyingsite/angiepolis.neocities.org/index.html
@@ -5,25 +5,7 @@
 <html lang="en">
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
 <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=edge" />
-    <script>
-      (function(d, s) {
-        var js = d.createElement(s),
-            sc = d.getElementsByTagName(s)[0];
-
-        js.src = "../static.wattpad.com/js/boomerang.99a8a777.min.js";
-        js.crossOrigin = 'anonymous';
-        sc.parentNode.insertBefore(js, sc);
-        if (document.addEventListener) {
-          document.addEventListener( "onBoomerangLoaded", function(e) {
-            e.detail.BOOMR.init( {
-              beacon_url: '/v4/metrics',
-              beacon_type: 'POST',
-              autorun: false
-            } );
-          } );
-        }
-      }(document, "script"));
-    </script>
+    <script>!function(d,s){var js=d.createElement(s),sc=d.getElementsByTagName(s)[0];js.src="../static.wattpad.com/js/boomerang.99a8a777.min.js";js.crossOrigin="anonymous";sc.parentNode.insertBefore(js,sc);document.addEventListener&&document.addEventListener("onBoomerangLoaded",function(e){e.detail.BOOMR.init({beacon_url:"/v4/metrics",beacon_type:"POST",autorun:false})})}(document,"script");</script>
 
     <meta charset="utf-8">
     <link rel="shortcut icon" href="http://static.wattpad.com/favicon.ico" />
@@ -69,9 +51,7 @@
   <link rel="stylesheet" type="text/css" href="../static.wattpad.com/css/desktop-web/desktop-web.d4472ed8.min.css">
 
 
-<style type="text/css" media="print">
-  main#parts-container-new { visibility: hidden; display: none }
-</style>
+<style type="text/css" media="print">main#parts-container-new{visibility:hidden;display:none}</style>
 <script type="text/javascript">
   document.cookie = "wp-web-page=; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=wattpad.com;  path=/;";
 </script>
@@ -93,17 +73,7 @@
 
 
 
-<script type="text/javascript">
-  ( function() {
-    var d = document;
-    var pbs = d.createElement( "script" );
-    pbs.type = "text/javascript";
-    pbs.src = "../static.wattpad.com/js/ados.ad0e6cf9.js";
-    pbs.crossOrigin = 'anonymous';
-    var target = d.getElementsByTagName( "head" )[ 0 ];
-    target.insertBefore( pbs, target.firstChild );
-  } )();
-</script>
+<script type="text/javascript">!function(){var d=document,pbs=d.createElement("script");pbs.type="text/javascript";pbs.src="../static.wattpad.com/js/ados.ad0e6cf9.js";pbs.crossOrigin="anonymous";var target=d.getElementsByTagName("head")[0];target.insertBefore(pbs,target.firstChild)}();</script>
 <script type="text/javascript">
     (function() {
       var wattpad = window.wattpad = ( window.wattpad || {} );


### PR DESCRIPTION
## Summary
- Condense inline boomerang loader script
- Minify print-only CSS rule
- Compress ad script loader

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba25eb4bec8327978197012d3e8737